### PR TITLE
fix(nuxt): restore error.vue rendering for SSR page errors

### DIFF
--- a/.changeset/fix-nuxt-error-page.md
+++ b/.changeset/fix-nuxt-error-page.md
@@ -2,7 +2,7 @@
 "evlog": patch
 ---
 
-fix(nuxt): restore `error.vue` rendering for SSR page errors
+# fix(nuxt): restore `error.vue` rendering for SSR page errors
 
 With `evlog/nuxt` installed, every non-API SSR error (404/500) was returned as raw Nitro JSON instead of rendering the framework error page. The Nitro error handler now delegates document/HTML navigations to the next handler in Nitro's chain (Nuxt's `error.vue` renderer) while still serializing JSON for API routes and `EvlogError` responses.
 

--- a/.changeset/fix-nuxt-error-page.md
+++ b/.changeset/fix-nuxt-error-page.md
@@ -1,0 +1,9 @@
+---
+"evlog": patch
+---
+
+fix(nuxt): restore `error.vue` rendering for SSR page errors
+
+With `evlog/nuxt` installed, every non-API SSR error (404/500) was returned as raw Nitro JSON instead of rendering the framework error page. The Nitro error handler now delegates document/HTML navigations to the next handler in Nitro's chain (Nuxt's `error.vue` renderer) while still serializing JSON for API routes and `EvlogError` responses.
+
+Closes #390

--- a/packages/evlog/src/nitro-v3/errorHandler.ts
+++ b/packages/evlog/src/nitro-v3/errorHandler.ts
@@ -5,6 +5,7 @@ import {
   extractErrorStatus,
   buildPlainNitroErrorBody,
   serializeEvlogErrorResponse,
+  shouldSerializeNitroErrorAsJson,
   shouldSuppressNitroDevOverlay,
   suppressNitroDevOverlay,
   markH3ErrorHandled,
@@ -21,7 +22,29 @@ import type { NitroErrorHandlerContext } from '../shared/nitro-types'
  * export { default } from 'evlog/nitro/v3/errorHandler'
  * ```
  */
+function getNitroV3RequestHeader(
+  headers: Headers | Record<string, string | string[] | undefined>,
+  name: string,
+): string | undefined {
+  if (headers instanceof Headers) {
+    return headers.get(name) ?? undefined
+  }
+  const lower = name.toLowerCase()
+  const value = headers[lower] ?? headers[name]
+  return Array.isArray(value) ? value[0] : value
+}
+
 export default defineErrorHandler(async (error, event, ctx: NitroErrorHandlerContext) => {
+  const evlogError = resolveEvlogError(error)
+  const requestUrl = parseURL(event.req.url)
+
+  if (!shouldSerializeNitroErrorAsJson({
+    pathname: requestUrl.pathname,
+    getHeader: name => getNitroV3RequestHeader(event.req.headers, name),
+  }, evlogError)) {
+    return
+  }
+
   const suppressOverlay = shouldSuppressNitroDevOverlay()
 
   if (!suppressOverlay) {
@@ -34,9 +57,8 @@ export default defineErrorHandler(async (error, event, ctx: NitroErrorHandlerCon
     suppressNitroDevOverlay(error)
   }
 
-  const url = parseURL(event.req.url).pathname
+  const url = requestUrl.pathname
   const isDev = process.env.NODE_ENV === 'development'
-  const evlogError = resolveEvlogError(error)
 
   const body = evlogError
     ? serializeEvlogErrorResponse(evlogError, url)

--- a/packages/evlog/src/nitro.ts
+++ b/packages/evlog/src/nitro.ts
@@ -115,6 +115,59 @@ export function resolveEvlogError(error: Error): Error | null {
 
 export { extractErrorStatus } from './shared/errors'
 
+/** Request metadata used to decide JSON vs framework error-page rendering. */
+export interface NitroErrorRequestContext {
+  pathname: string
+  getHeader(name: string): string | undefined
+}
+
+function acceptIncludes(accept: string | undefined, mediaType: string): boolean {
+  return accept?.toLowerCase().includes(mediaType) ?? false
+}
+
+function isNitroApiPath(pathname: string): boolean {
+  return pathname.startsWith('/api/')
+}
+
+/**
+ * Whether evlog's Nitro error handler should flush a JSON body itself.
+ *
+ * Returns `false` for document/page requests so Nitro can delegate to the next
+ * handler in the chain (e.g. Nuxt's `error.vue` renderer). EvlogError and API
+ * routes always serialize as JSON.
+ *
+ * @internal
+ */
+export function shouldSerializeNitroErrorAsJson(
+  request: NitroErrorRequestContext,
+  evlogError: Error | null,
+): boolean {
+  if (evlogError) return true
+
+  const { pathname, getHeader } = request
+
+  if (isNitroApiPath(pathname)) return true
+
+  const secFetchDest = getHeader('sec-fetch-dest')
+  if (secFetchDest === 'document') return false
+
+  const secFetchMode = getHeader('sec-fetch-mode')
+  if (secFetchMode === 'navigate') return false
+
+  const accept = getHeader('accept')
+
+  if (getHeader('x-requested-with')?.toLowerCase() === 'xmlhttprequest') return true
+
+  if (acceptIncludes(accept, 'application/json') && !acceptIncludes(accept, 'text/html')) {
+    return true
+  }
+
+  if (acceptIncludes(accept, 'text/html')) return false
+
+  // fetch/curl without HTML signals — preserve standalone Nitro JSON behavior
+  return true
+}
+
 /**
  * Mark an h3 event handled synchronously.
  * Nitro chains a built-in dev handler after custom handlers; `send()` defers

--- a/packages/evlog/src/nitro.ts
+++ b/packages/evlog/src/nitro.ts
@@ -126,7 +126,7 @@ function acceptIncludes(accept: string | undefined, mediaType: string): boolean 
 }
 
 function isNitroApiPath(pathname: string): boolean {
-  return pathname.startsWith('/api/')
+  return pathname === '/api' || pathname.startsWith('/api/')
 }
 
 /**

--- a/packages/evlog/src/nitro/errorHandler.ts
+++ b/packages/evlog/src/nitro/errorHandler.ts
@@ -1,7 +1,7 @@
 // Import from specific subpath — the barrel 'nitropack/runtime' re-exports from
 // internal/app.mjs which imports virtual modules that crash outside rollup builds.
 import { defineNitroErrorHandler } from 'nitropack/runtime/internal/error/utils'
-import { getRequestURL, setResponseHeader, setResponseStatus } from 'h3'
+import { getRequestHeader, getRequestURL, setResponseHeader, setResponseStatus } from 'h3'
 import type { H3Event } from 'h3'
 import {
   resolveEvlogError,
@@ -9,6 +9,7 @@ import {
   buildPlainNitroErrorBody,
   serializeEvlogErrorResponse,
   markH3ErrorHandled,
+  shouldSerializeNitroErrorAsJson,
   shouldSuppressNitroDevOverlay,
   suppressNitroDevOverlay,
 } from '../nitro'
@@ -36,6 +37,16 @@ function endNodeResponse(event: H3Event, body: string): void {
  * sanitizing internal error details in production for 5xx errors.
  */
 export default defineNitroErrorHandler(async (error, event, ctx) => {
+  const evlogError = resolveEvlogError(error)
+  const requestUrl = getRequestURL(event, { xForwardedHost: true })
+
+  if (!shouldSerializeNitroErrorAsJson({
+    pathname: requestUrl.pathname,
+    getHeader: name => getRequestHeader(event, name),
+  }, evlogError)) {
+    return
+  }
+
   const suppressOverlay = shouldSuppressNitroDevOverlay()
 
   // Nitro v2 always passes `ctx`, but a missing context (e.g. the handler
@@ -49,10 +60,8 @@ export default defineNitroErrorHandler(async (error, event, ctx) => {
     suppressNitroDevOverlay(error)
   }
 
-  const evlogError = resolveEvlogError(error)
-
   const isDev = process.env.NODE_ENV === 'development'
-  const url = getRequestURL(event, { xForwardedHost: true }).pathname
+  const url = requestUrl.pathname
 
   if (!evlogError) {
     const body = buildPlainNitroErrorBody(error, url, isDev)

--- a/packages/evlog/test/nitro-v3/errorHandler.test.ts
+++ b/packages/evlog/test/nitro-v3/errorHandler.test.ts
@@ -16,9 +16,20 @@ import { resetNitroDevOverlayCache, shouldSuppressNitroDevOverlay } from '../../
 const defaultHandlerMock = vi.fn().mockResolvedValue(undefined)
 
 const mockEvent = {
-  req: { url: 'http://localhost/api/test' },
+  req: {
+    url: 'http://localhost/api/test',
+    headers: new Headers(),
+  },
   _handled: false,
-} as { req: { url: string }; _handled: boolean }
+} as { req: { url: string; headers: Headers }; _handled: boolean }
+
+function setMockHeaders(headers: Record<string, string>) {
+  mockEvent.req.headers = new Headers(headers)
+}
+
+function setMockPath(pathname: string) {
+  mockEvent.req.url = `http://localhost${pathname}`
+}
 
 function invokeErrorHandler(error: Error, event = mockEvent) {
   return errorHandler(error, event, { defaultHandler: defaultHandlerMock })
@@ -36,6 +47,8 @@ describe('nitro-v3 errorHandler', () => {
     delete globalThis.__EVLOG_CONFIG__
     resetNitroDevOverlayCache()
     mockEvent._handled = false
+    setMockPath('/api/test')
+    mockEvent.req.headers = new Headers()
   })
 
   it('marks the h3 event handled so Nitro dev handler does not run', async () => {
@@ -206,6 +219,43 @@ describe('nitro-v3 errorHandler', () => {
       const body = await readJson(await invokeErrorHandler(error))
       expect(body.message).toBe('Invalid email format')
       expect(body.statusMessage).toBe('Invalid email format')
+    })
+  })
+
+  describe('HTML page delegation (#390)', () => {
+    it('returns undefined for plain errors on document navigation', async () => {
+      setMockPath('/user/does-not-exist')
+      setMockHeaders({
+        accept: 'text/html,application/xhtml+xml',
+        'sec-fetch-dest': 'document',
+      })
+
+      const error = Object.assign(new Error('nope'), { statusCode: 404 })
+      const response = await invokeErrorHandler(error)
+
+      expect(response).toBeUndefined()
+      expect(mockEvent._handled).toBe(false)
+      expect(defaultHandlerMock).not.toHaveBeenCalled()
+    })
+
+    it('still serializes EvlogError on document navigation', async () => {
+      setMockPath('/checkout')
+      setMockHeaders({
+        accept: 'text/html',
+        'sec-fetch-dest': 'document',
+      })
+
+      const evlogError = Object.assign(new Error('Payment failed'), {
+        name: 'EvlogError',
+        status: 402,
+        statusCode: 402,
+        data: { why: 'Card declined' },
+      })
+
+      const response = await invokeErrorHandler(evlogError)
+
+      expect(response?.status).toBe(402)
+      expect(await readJson(response!)).toMatchObject({ statusCode: 402, data: { why: 'Card declined' } })
     })
   })
 })

--- a/packages/evlog/test/nitro/error-content-negotiation.test.ts
+++ b/packages/evlog/test/nitro/error-content-negotiation.test.ts
@@ -45,6 +45,13 @@ describe('shouldSerializeNitroErrorAsJson', () => {
     )).toBe(true)
   })
 
+  it('serializes plain errors on the /api root path', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/api', { accept: 'text/html', 'sec-fetch-dest': 'document' }),
+      null,
+    )).toBe(true)
+  })
+
   it('serializes plain errors for JSON-only Accept headers', () => {
     expect(shouldSerializeNitroErrorAsJson(
       request('/page', { accept: 'application/json' }),

--- a/packages/evlog/test/nitro/error-content-negotiation.test.ts
+++ b/packages/evlog/test/nitro/error-content-negotiation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { shouldSerializeNitroErrorAsJson, type NitroErrorRequestContext } from '../../src/nitro'
+
+function request(
+  pathname: string,
+  headers: Record<string, string> = {},
+): NitroErrorRequestContext {
+  return {
+    pathname,
+    getHeader: name => headers[name.toLowerCase()] ?? headers[name],
+  }
+}
+
+describe('shouldSerializeNitroErrorAsJson', () => {
+  const evlogError = Object.assign(new Error('structured'), { name: 'EvlogError' })
+
+  it('always serializes EvlogError even for HTML navigation', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/about', { accept: 'text/html', 'sec-fetch-dest': 'document' }),
+      evlogError,
+    )).toBe(true)
+  })
+
+  it('delegates plain SSR errors on HTML document requests', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/user/does-not-exist', {
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'sec-fetch-dest': 'document',
+      }),
+      null,
+    )).toBe(false)
+  })
+
+  it('delegates plain errors when Sec-Fetch-Mode is navigate', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/missing', { 'sec-fetch-mode': 'navigate' }),
+      null,
+    )).toBe(false)
+  })
+
+  it('serializes plain errors on API routes', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/api/users', { accept: 'text/html' }),
+      null,
+    )).toBe(true)
+  })
+
+  it('serializes plain errors for JSON-only Accept headers', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/page', { accept: 'application/json' }),
+      null,
+    )).toBe(true)
+  })
+
+  it('serializes plain errors for XMLHttpRequest clients', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/page', {
+        accept: 'text/html',
+        'x-requested-with': 'XMLHttpRequest',
+      }),
+      null,
+    )).toBe(true)
+  })
+
+  it('serializes plain errors for fetch-like requests without HTML signals', () => {
+    expect(shouldSerializeNitroErrorAsJson(
+      request('/throws-plain', { accept: '*/*' }),
+      null,
+    )).toBe(true)
+  })
+})

--- a/packages/evlog/test/nitro/errorHandler.test.ts
+++ b/packages/evlog/test/nitro/errorHandler.test.ts
@@ -10,12 +10,17 @@ declare global {
 const mockSetResponseStatus = vi.fn<(event: H3Event, status: number) => void>()
 const mockSetResponseHeader = vi.fn<(event: H3Event, name: string, value: string) => void>()
 const mockGetRequestURL = vi.fn<(event: H3Event, options?: { xForwardedHost?: boolean }) => { pathname: string }>(() => ({ pathname: '/api/test' }))
+const mockGetRequestHeader = vi.fn<(event: H3Event, name: string) => string | undefined>((event, name) => {
+  const headers = (event as typeof mockEvent).node.req.headers as Record<string, string> | undefined
+  return headers?.[name.toLowerCase()] ?? headers?.[name]
+})
 const mockResponseEnd = vi.fn<(body?: string) => void>()
 
 vi.mock('h3', () => ({
   setResponseStatus: (event: H3Event, status: number) => mockSetResponseStatus(event, status),
   setResponseHeader: (event: H3Event, name: string, value: string) => mockSetResponseHeader(event, name, value),
   getRequestURL: (event: H3Event, options?: { xForwardedHost?: boolean }) => mockGetRequestURL(event, options),
+  getRequestHeader: (event: H3Event, name: string) => mockGetRequestHeader(event, name),
 }))
 
 import { createError } from '../../src/error'
@@ -23,9 +28,9 @@ import errorHandler from '../../src/nitro/errorHandler'
 import { resetNitroDevOverlayCache, shouldSuppressNitroDevOverlay } from '../../src/nitro'
 
 const mockEvent = {
-  node: { req: {}, res: { writableEnded: false, end: mockResponseEnd } },
+  node: { req: { headers: {} as Record<string, string> }, res: { writableEnded: false, end: mockResponseEnd } },
   _handled: false,
-} as unknown as H3Event & { _handled: boolean; node: { res: { writableEnded: boolean; end: typeof mockResponseEnd } } }
+} as unknown as H3Event & { _handled: boolean; node: { req: { headers: Record<string, string> }; res: { writableEnded: boolean; end: typeof mockResponseEnd } } }
 
 const defaultHandlerMock = vi.fn().mockResolvedValue(undefined)
 
@@ -57,6 +62,8 @@ describe('errorHandler', () => {
     resetNitroDevOverlayCache()
     mockEvent._handled = false
     mockEvent.node.res.writableEnded = false
+    mockEvent.node.req.headers = {}
+    mockGetRequestURL.mockReturnValue({ pathname: '/api/test' })
   })
 
   it('marks the h3 event handled so Nitro dev handler does not run', async () => {
@@ -250,6 +257,74 @@ describe('errorHandler', () => {
       const sentBody = readResponseBody()
       expect(sentBody.message).toBe('Invalid email format')
       expect(sentBody.statusMessage).toBe('Invalid email format')
+    })
+  })
+
+  describe('HTML page delegation (#390)', () => {
+    it('does not flush JSON for plain errors on document navigation', async () => {
+      mockGetRequestURL.mockReturnValue({ pathname: '/user/does-not-exist' })
+      mockEvent.node.req.headers = {
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'sec-fetch-dest': 'document',
+      }
+
+      const error = Object.assign(new Error('nope'), { statusCode: 404, statusMessage: 'nope' })
+      await invokeErrorHandler(error)
+
+      expect(mockResponseEnd).not.toHaveBeenCalled()
+      expect(mockEvent._handled).toBe(false)
+      expect(defaultHandlerMock).not.toHaveBeenCalled()
+    })
+
+    it('still serializes EvlogError on document navigation', async () => {
+      mockGetRequestURL.mockReturnValue({ pathname: '/checkout' })
+      mockEvent.node.req.headers = {
+        accept: 'text/html',
+        'sec-fetch-dest': 'document',
+      }
+
+      const evlogError = Object.assign(new Error('Payment failed'), {
+        name: 'EvlogError',
+        status: 402,
+        statusCode: 402,
+        data: { why: 'Card declined' },
+      })
+
+      await invokeErrorHandler(evlogError)
+
+      expect(mockResponseEnd).toHaveBeenCalled()
+      expect(readResponseBody().statusCode).toBe(402)
+    })
+  })
+
+  describe('chained Nitro error handlers (#390)', () => {
+    it('passes HTML page errors to the next handler in the chain', async () => {
+      const frameworkHandler = vi.fn().mockResolvedValue(
+        new Response('<html>error page</html>', { status: 404, headers: { 'Content-Type': 'text/html' } }),
+      )
+
+      mockGetRequestURL.mockReturnValue({ pathname: '/missing-page' })
+      mockEvent.node.req.headers = {
+        accept: 'text/html',
+        'sec-fetch-mode': 'navigate',
+      }
+
+      const error = Object.assign(new Error('Not Found'), { statusCode: 404 })
+      const handlers = [testErrorHandler, frameworkHandler]
+
+      let response: Response | undefined
+      for (const handler of handlers) {
+        const result = await handler(error, mockEvent, { defaultHandler: defaultHandlerMock })
+        if (result) {
+          response = result as Response
+          break
+        }
+      }
+
+      expect(mockResponseEnd).not.toHaveBeenCalled()
+      expect(frameworkHandler).toHaveBeenCalledOnce()
+      expect(response?.status).toBe(404)
+      expect(await response?.text()).toContain('error page')
     })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed SSR error handling so non-API page errors render the framework’s error page instead of returning raw Nitro JSON (e.g., 404/500 during page navigation).
  * Preserved JSON error responses for API routes and API-like requests, including `EvlogError` cases.
* **Tests**
  * Added/updated coverage for HTML navigation vs API-style content negotiation and chained error-handler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #390