### PR TITLE
fix(core): enhance pipeline retries and update related documentation

### DIFF
--- a/.agents/skills/create-adapter/references/adapter-template.md
+++ b/.agents/skills/create-adapter/references/adapter-template.md
@@ -137,6 +137,7 @@ export async function sendBatchTo{Name}(events: WideEvent[], config: {Name}Confi
 - Skipping silently when `resolve()` returns `null`
 - Transport via `httpPost` (`../shared/http`): timeout (default 5000ms), retries (default 2), evlog identity headers (`User-Agent: evlog/x.y.z`, `X-Evlog-Source`)
 - Error logging (`[evlog/{name}] Failed to send events:`) that never throws into the request pipeline
+- A `raw` variant on the returned drain that rejects on failure and performs a single attempt (unless `retries` is set on the config). `createDrainPipeline` uses it so its retry/`onDropped` own failures; never swallow errors inside `encode` or a custom `send`
 
 ## Customization Notes
 

--- a/.agents/skills/create-adapter/references/test-template.md
+++ b/.agents/skills/create-adapter/references/test-template.md
@@ -162,7 +162,7 @@ describe('{name} adapter', () => {
 - **Auth headers**: Match the service (`X-API-Key`, HTTP Basic, `X-ClickHouse-User`, …).
 - **Body format**: Wrapper objects (PostHog `{ api_key, batch }`), raw arrays (Axiom), NDJSON (ClickHouse). Assert the real structure, not just "is an array".
 - **Deprecated aliases**: If the adapter supports one (`token` → `apiKey`), add a test that the alias still resolves and that the canonical name wins when both are set.
-- **Error swallowing**: The drain itself never throws. That contract lives in `defineHttpDrain` and is covered by `test/toolkit/toolkit.test.ts`; don't re-test it per adapter. Only direct helpers surface errors.
+- **Error swallowing**: The drain itself never throws; its `raw` variant rejects and single-attempts so the pipeline can own retries. Both contracts live in `defineHttpDrain` and are covered by `test/toolkit/toolkit.test.ts`; don't re-test them per adapter. Only direct helpers surface errors.
 - **Service-specific helpers**: Every exported helper (`buildLokiPayload`, `toClickHouseRow`, severity mappers…) gets its own `describe` with edge cases (empty input, malformed timestamps, cardinality guards).
 
 ## Beyond unit tests

--- a/.changeset/pipeline-owns-adapter-failures.md
+++ b/.changeset/pipeline-owns-adapter-failures.md
@@ -1,0 +1,7 @@
+---
+"evlog": minor
+---
+
+Wrapping an adapter drain in `createDrainPipeline` now behaves as documented. Adapter drains swallow delivery failures so they never break a request, which silently disabled the pipeline's `retry` and `onDropped` and stacked the adapter's internal HTTP retries on top of the pipeline's. Drains built with `defineDrain` / `defineHttpDrain` now expose a throwing `raw` variant that performs a single attempt unless retries are explicitly configured, and the pipeline picks it up automatically: `retry` and `onDropped` observe real failures, and one layer owns retrying. A batch dropped with no `onDropped` configured is logged instead of vanishing.
+
+On serverless runtimes the pipeline no longer strands buffered events. It exposes `settled()`, which resolves once everything buffered so far has been delivered or dropped, and the shared middleware registers it with the runtime's `waitUntil` (Next's `after()`, Workers' `ctx.waitUntil`) so the instance is not frozen while a batch sits in the buffer.

--- a/apps/docs/content/4.integrate/frameworks/02.nextjs.md
+++ b/apps/docs/content/4.integrate/frameworks/02.nextjs.md
@@ -244,6 +244,10 @@ export const { withEvlog, useLogger, log, createError } = createEvlog({
 ```
 ::
 
+::callout{icon="i-lucide-cloud" color="neutral"}
+On Vercel, `withEvlog` registers drain work with Next's `after()`, and with a pipeline it also registers `drain.settled()`: the function stays alive until the buffered batch reaches Axiom, delayed by at most `batch.intervalMs`. If your ingest endpoint is slow enough to hit the default 5s request timeout, raise it (`createAxiomDrain({ timeout: 15000 })`): a timed-out request that actually landed gets retried, and non-idempotent ingest APIs count that twice.
+::
+
 ## Wide Events
 
 Build up context progressively through your handler. One request = one wide event:

--- a/apps/docs/content/4.integrate/frameworks/02.nextjs.md
+++ b/apps/docs/content/4.integrate/frameworks/02.nextjs.md
@@ -245,7 +245,7 @@ export const { withEvlog, useLogger, log, createError } = createEvlog({
 ::
 
 ::callout{icon="i-lucide-cloud" color="neutral"}
-On Vercel, `withEvlog` registers drain work with Next's `after()`, and with a pipeline it also registers `drain.settled()`: the function stays alive until the buffered batch reaches Axiom, delayed by at most `batch.intervalMs`. If your ingest endpoint is slow enough to hit the default 5s request timeout, raise it (`createAxiomDrain({ timeout: 15000 })`): a timed-out request that actually landed gets retried, and non-idempotent ingest APIs count that twice.
+On Vercel, `withEvlog` registers drain work with Next's `after()`, and with a pipeline it also registers `drain.settled()`: the function stays alive until the buffered batch is delivered, or dropped once retries are exhausted. `batch.intervalMs` bounds when the first delivery attempt starts; retry backoff can extend the lifetime past it. If your ingest endpoint is slow enough to hit the default 5s request timeout, raise it (`createAxiomDrain({ timeout: 15000 })`): a timed-out request that actually landed gets retried, and non-idempotent ingest APIs count that twice.
 ::
 
 ## Wide Events

--- a/apps/docs/content/6.extend/8.custom-drains.md
+++ b/apps/docs/content/6.extend/8.custom-drains.md
@@ -107,7 +107,7 @@ export function createMyServiceDrain(overrides?: Partial<MyServiceConfig>) {
 ```
 ::
 
-That's it. `defineHttpDrain` handles batching, retries (default 2), timeouts (default 5000ms), error isolation, and the identity headers (`User-Agent: evlog/<version>` + `X-Evlog-Source: <name>`). Your app pipeline keeps running even if your destination is down.
+That's it. `defineHttpDrain` handles retries (default 2), timeouts (default 5000ms), error isolation, and the identity headers (`User-Agent: evlog/<version>` + `X-Evlog-Source: <name>`). Your app pipeline keeps running even if your destination is down, and when you wrap the drain in [`createDrainPipeline`](/extend/drain-pipeline), the pipeline takes over retries through the drain's `raw` variant.
 
 ### A 5-minute example: internal Loki drain
 
@@ -236,7 +236,7 @@ export const createCustomTransportDrain = () =>
   })
 ```
 
-When you fall back to `defineDrain`, follow the same rules manually that `defineHttpDrain` enforces: wrap the transport in `try/catch`, log with `console.error('[evlog/<name>] …')`, and never re-throw.
+Let `send` throw on failure. `defineDrain` handles the isolation: a direct call swallows the error and logs it with your drain's name, while the `raw` variant on the returned function rejects, which is how [the pipeline](/extend/drain-pipeline)'s retry and `onDropped` observe failures. A `send` that swallows its own errors makes your drain unretryable.
 
 ## What a DrainContext carries
 

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -129,7 +129,7 @@ Events are buffered as they arrive on `evlog:drain`. A batch flushes when either
 
 ### The pipeline owns retries
 
-Adapter drains (`createAxiomDrain()`, `createDatadogDrain()`, …) swallow delivery failures when called directly, so a failing backend never breaks a request. Inside the pipeline that would make `retry` and `onDropped` dead code, so the pipeline unwraps the adapter to its throwing `raw` variant: failures reach the retry loop, and the adapter's internal HTTP retries are skipped so the batch isn't retried twice. Set `retries` on the adapter config only if you explicitly want attempts inside each pipeline attempt.
+Adapter drains (`createAxiomDrain()`, `createDatadogDrain()`, …) swallow delivery failures when called directly, so a failing backend never breaks a request. Inside the pipeline that would make `retry` and `onDropped` dead code, so the pipeline unwraps the adapter to its throwing `raw` variant: failures reach the retry loop, and raw delivery defaults to a single HTTP attempt so the batch isn't retried twice. Set `retries` on the adapter config only if you explicitly want extra HTTP attempts inside each pipeline attempt.
 
 ## Configuration
 

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -45,7 +45,7 @@ Wrap my evlog drain in the shared pipeline so it batches, retries, and survives 
 - Wrap the underlying drain: `const drain = createDrainPipeline<DrainContext>()(createAxiomDrain())`
 - Configure `batch` (size + intervalMs), `retry` (maxAttempts + backoff), and `maxBufferSize` (oldest events drop on overflow). Sane defaults: `{ batch: { size: 50, intervalMs: 5000 }, retry: { maxAttempts: 3 } }`
 - For multiple destinations, write a single drain function that fans out internally with `Promise.allSettled([drainA(batch), drainB(batch)])` and pass that to `pipeline(...)`. One shared buffer, one shared retry budget
-- On shutdown, call `drain.flush()` to push buffered events (frameworks with proper lifecycle do this automatically: Nitro `close` hook, Standalone before `process.exit`, serverless via `waitUntil(drain.flush())`)
+- On shutdown, call `drain.flush()` to push buffered events (Nitro `close` hook, Standalone before `process.exit`). On serverless, passing the pipeline as the `drain` option is enough: the middleware registers `drain.settled()` with the runtime's `waitUntil`
 - Always use the pipeline in production. Direct drains make one HTTP call per event and fall over fast
 
 Docs: https://www.evlog.dev/extend/drain-pipeline
@@ -120,12 +120,16 @@ await drain.flush() // before exit
 ::
 
 ::callout{icon="i-lucide-alert-triangle" color="warning"}
-Always flush the pipeline before the process exits (`drain.flush()`). On Nitro use the `close` hook; on standalone scripts call it before `process.exit`; on serverless runtimes use `waitUntil(drain.flush())`.
+Always flush the pipeline before the process exits (`drain.flush()`). On Nitro use the `close` hook; on standalone scripts call it before `process.exit`. On serverless runtimes the middleware extends the instance's lifetime for you, see [Serverless](#serverless).
 ::
 
 ## What the pipeline does to an event
 
-Events are buffered as they arrive on `evlog:drain`. A batch flushes when either `batch.size` is reached or `batch.intervalMs` expires (whichever comes first). On failure, the same batch is retried with the configured backoff; once `retry.maxAttempts` is exhausted, `onDropped` is called with the lost events. The buffer is bounded by `maxBufferSize`. Once full, the oldest events are dropped to keep memory flat.
+Events are buffered as they arrive on `evlog:drain`. A batch flushes when either `batch.size` is reached or `batch.intervalMs` expires (whichever comes first). On failure, the same batch is retried with the configured backoff; once `retry.maxAttempts` is exhausted, `onDropped` is called with the lost events (or the drop is logged when you didn't configure one). The buffer is bounded by `maxBufferSize`. Once full, the oldest events are dropped to keep memory flat.
+
+### The pipeline owns retries
+
+Adapter drains (`createAxiomDrain()`, `createDatadogDrain()`, …) swallow delivery failures when called directly, so a failing backend never breaks a request. Inside the pipeline that would make `retry` and `onDropped` dead code, so the pipeline unwraps the adapter to its throwing `raw` variant: failures reach the retry loop, and the adapter's internal HTTP retries are skipped so the batch isn't retried twice. Set `retries` on the adapter config only if you explicitly want attempts inside each pipeline attempt.
 
 ## Configuration
 
@@ -183,7 +187,14 @@ The function returned by `pipeline(drain)` is hook-compatible and exposes:
 |----------|------|-------------|
 | `drain(ctx)` | `(ctx: T) => void` | Push a single event into the buffer |
 | `drain.flush()` | `() => Promise<void>` | Force-flush all buffered events |
+| `drain.settled()` | `() => Promise<void>` | Resolves once everything buffered so far is delivered or dropped, without forcing a flush |
 | `drain.pending` | `number` | Number of events currently buffered |
+
+## Serverless
+
+`drain(ctx)` returns after buffering, so on a serverless runtime the interesting question is what keeps the instance alive until the batch actually ships. When you pass the pipeline as the `drain` option of a framework integration, the middleware registers `drain.settled()` with the runtime's `waitUntil` (Next's `after()`, Workers' `ctx.waitUntil`): the instance stays alive until the buffered batch is delivered or dropped, delayed by at most `batch.intervalMs`. Lower `intervalMs` on serverless if you'd rather trade batching for shorter post-response lifetimes.
+
+Nitro is the exception: drains registered on the `evlog:drain` hook are opaque to the plugin, so it can't extend the lifetime for you. On Node the `close` hook flush from the quick start covers shutdown; on Cloudflare register `drain.settled()` with the execution context's `waitUntil` yourself where you handle the request.
 
 ## Fanout
 

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -192,7 +192,7 @@ The function returned by `pipeline(drain)` is hook-compatible and exposes:
 
 ## Serverless
 
-`drain(ctx)` returns after buffering, so on a serverless runtime the interesting question is what keeps the instance alive until the batch actually ships. When you pass the pipeline as the `drain` option of a framework integration, the middleware registers `drain.settled()` with the runtime's `waitUntil` (Next's `after()`, Workers' `ctx.waitUntil`): the instance stays alive until the buffered batch is delivered or dropped, delayed by at most `batch.intervalMs`. Lower `intervalMs` on serverless if you'd rather trade batching for shorter post-response lifetimes.
+`drain(ctx)` returns after buffering, so on a serverless runtime the interesting question is what keeps the instance alive until the batch actually ships. When you pass the pipeline as the `drain` option of a framework integration, the middleware registers `drain.settled()` with the runtime's `waitUntil` (Next's `after()`, Workers' `ctx.waitUntil`): the instance stays alive until the buffered batch is delivered or dropped. `batch.intervalMs` bounds when the first delivery attempt starts; retry backoff can extend the lifetime past it until delivery succeeds or `retry.maxAttempts` is exhausted. Lower `intervalMs` on serverless if you'd rather trade batching for shorter post-response lifetimes.
 
 Nitro is the exception: drains registered on the `evlog:drain` hook are opaque to the plugin, so it can't extend the lifetime for you. On Node the `close` hook flush from the quick start covers shutdown; on Cloudflare register `drain.settled()` with the execution context's `waitUntil` yourself where you handle the request.
 

--- a/apps/docs/skills/review-logging-patterns/references/drain-pipeline.md
+++ b/apps/docs/skills/review-logging-patterns/references/drain-pipeline.md
@@ -82,7 +82,7 @@ drain.pending         // Number of events currently buffered (readonly)
 
 ## Serverless
 
-`drain(ctx)` returns after buffering, so delivery must outlive the response. When the pipeline is passed as the `drain` option of a framework integration, the shared middleware registers `drain.settled()` with the runtime's `waitUntil` (Next `after()`, Workers `ctx.waitUntil`) automatically: the instance stays alive until the batch ships, delayed by at most `batch.intervalMs`. Nitro's `evlog:drain` hook path can't do this for you; on Cloudflare register `drain.settled()` with the execution context's `waitUntil` where the hook is wired.
+`drain(ctx)` returns after buffering, so delivery must outlive the response. When the pipeline is passed as the `drain` option of a framework integration, the shared middleware registers `drain.settled()` with the runtime's `waitUntil` (Next `after()`, Workers `ctx.waitUntil`) automatically: the instance stays alive until the batch is delivered or dropped. `batch.intervalMs` bounds when the first delivery attempt starts; retry backoff can extend the lifetime past it. Nitro's `evlog:drain` hook path can't do this for you; on Cloudflare register `drain.settled()` with the execution context's `waitUntil` where the hook is wired.
 
 ## Common Patterns
 

--- a/apps/docs/skills/review-logging-patterns/references/drain-pipeline.md
+++ b/apps/docs/skills/review-logging-patterns/references/drain-pipeline.md
@@ -56,7 +56,7 @@ const pipeline = createDrainPipeline<DrainContext>({
 2. When `buffer.length >= batch.size`, the batch is flushed immediately
 3. If the batch isn't full, a timer starts; after `intervalMs`, whatever is buffered gets flushed
 4. On flush, the drain function receives `T[]` (always an array)
-5. Adapter drains built with `defineDrain` / `defineHttpDrain` are unwrapped to their throwing `raw` variant, which skips the adapter's internal HTTP retries: the pipeline is the single retry owner
+5. Adapter drains built with `defineDrain` / `defineHttpDrain` are unwrapped to their throwing `raw` variant, which defaults to one HTTP attempt per pipeline attempt: the pipeline owns retries, unless `retries` is explicitly configured on the adapter, which then still applies inside each pipeline attempt
 6. If the drain throws, the batch is retried with the configured backoff
 7. After `maxAttempts` failures, `onDropped` is called and the batch is discarded (logged when no `onDropped` is configured)
 8. If the buffer exceeds `maxBufferSize`, the oldest event is dropped and `onDropped` is called

--- a/apps/docs/skills/review-logging-patterns/references/drain-pipeline.md
+++ b/apps/docs/skills/review-logging-patterns/references/drain-pipeline.md
@@ -56,9 +56,10 @@ const pipeline = createDrainPipeline<DrainContext>({
 2. When `buffer.length >= batch.size`, the batch is flushed immediately
 3. If the batch isn't full, a timer starts; after `intervalMs`, whatever is buffered gets flushed
 4. On flush, the drain function receives `T[]` (always an array)
-5. If the drain throws, the batch is retried with the configured backoff
-6. After `maxAttempts` failures, `onDropped` is called and the batch is discarded
-7. If the buffer exceeds `maxBufferSize`, the oldest event is dropped and `onDropped` is called
+5. Adapter drains built with `defineDrain` / `defineHttpDrain` are unwrapped to their throwing `raw` variant, which skips the adapter's internal HTTP retries: the pipeline is the single retry owner
+6. If the drain throws, the batch is retried with the configured backoff
+7. After `maxAttempts` failures, `onDropped` is called and the batch is discarded (logged when no `onDropped` is configured)
+8. If the buffer exceeds `maxBufferSize`, the oldest event is dropped and `onDropped` is called
 
 ## Backoff Strategies
 
@@ -73,10 +74,15 @@ const pipeline = createDrainPipeline<DrainContext>({
 ```typescript
 const drain = pipeline(myDrainFn)
 
-drain(ctx)          // Push a single event (synchronous, non-blocking)
-await drain.flush() // Force-flush all buffered events
-drain.pending       // Number of events currently buffered (readonly)
+drain(ctx)            // Push a single event (synchronous, non-blocking)
+await drain.flush()   // Force-flush all buffered events
+await drain.settled() // Resolves once everything buffered is delivered or dropped, without forcing a flush
+drain.pending         // Number of events currently buffered (readonly)
 ```
+
+## Serverless
+
+`drain(ctx)` returns after buffering, so delivery must outlive the response. When the pipeline is passed as the `drain` option of a framework integration, the shared middleware registers `drain.settled()` with the runtime's `waitUntil` (Next `after()`, Workers `ctx.waitUntil`) automatically: the instance stays alive until the batch ships, delayed by at most `batch.intervalMs`. Nitro's `evlog:drain` hook path can't do this for you; on Cloudflare register `drain.settled()` with the execution context's `waitUntil` where the hook is wired.
 
 ## Common Patterns
 
@@ -152,7 +158,9 @@ nitroApp.hooks.hook('close', () => drain.flush())
 ## Review Checklist
 
 - [ ] Pipeline wraps the adapter for production use
-- [ ] `drain.flush()` called on server `close` hook
+- [ ] `drain.flush()` called on server `close` hook (long-lived servers)
+- [ ] On serverless, the pipeline is passed as the integration's `drain` option (settled() registration is automatic); Nitro-on-Cloudflare wires `drain.settled()` into `waitUntil` manually
 - [ ] `onDropped` callback logs or reports dropped events
+- [ ] Retries are owned by one layer: no explicit `retries` on the adapter config when the pipeline wraps it
 - [ ] Batch size and interval are appropriate for the traffic volume
 - [ ] `maxBufferSize` is set to prevent memory leaks under load

--- a/packages/evlog/src/pipeline.ts
+++ b/packages/evlog/src/pipeline.ts
@@ -112,9 +112,14 @@ export function createDrainPipeline<T = unknown>(options?: DrainPipelineOptions<
     let timer: ReturnType<typeof setTimeout> | null = null
     let activeFlush: Promise<void> | null = null
     let settleWaiters: Array<() => void> = []
+    let activeFlushCalls = 0
+
+    function isIdle(): boolean {
+      return buffer.length === 0 && !activeFlush && activeFlushCalls === 0
+    }
 
     function notifySettled(): void {
-      if (buffer.length > 0 || activeFlush || settleWaiters.length === 0) return
+      if (!isIdle() || settleWaiters.length === 0) return
       const waiters = settleWaiters
       settleWaiters = []
       for (const resolve of waiters) resolve()
@@ -211,23 +216,29 @@ export function createDrainPipeline<T = unknown>(options?: DrainPipelineOptions<
 
     async function flush(): Promise<void> {
       clearTimer()
-      if (activeFlush) {
-        await activeFlush
-      }
-      // Snapshot the buffer length to avoid infinite loop if push() is called during flush
-      const snapshot = buffer.length
-      if (snapshot > 0) {
-        const toFlush = buffer.splice(0, snapshot)
-        while (toFlush.length > 0) {
-          const batch = toFlush.splice(0, batchSize)
-          await sendWithRetry(batch)
+      // Counted so settled() stays pending while a spliced batch is in flight.
+      activeFlushCalls++
+      try {
+        if (activeFlush) {
+          await activeFlush
         }
+        // Snapshot the buffer length to avoid infinite loop if push() is called during flush
+        const snapshot = buffer.length
+        if (snapshot > 0) {
+          const toFlush = buffer.splice(0, snapshot)
+          while (toFlush.length > 0) {
+            const batch = toFlush.splice(0, batchSize)
+            await sendWithRetry(batch)
+          }
+        }
+      } finally {
+        activeFlushCalls--
+        notifySettled()
       }
-      notifySettled()
     }
 
     function settled(): Promise<void> {
-      if (buffer.length === 0 && !activeFlush) return Promise.resolve()
+      if (isIdle()) return Promise.resolve()
       return new Promise<void>((resolve) => {
         settleWaiters.push(resolve)
       })

--- a/packages/evlog/src/pipeline.ts
+++ b/packages/evlog/src/pipeline.ts
@@ -25,6 +25,12 @@ export interface PipelineDrainFn<T> {
   (ctx: T): void
   /** Flush all buffered events. Call on server shutdown. */
   flush: () => Promise<void>
+  /**
+   * Resolves once everything buffered so far has been delivered or dropped,
+   * without forcing an early flush. Serverless integrations register it with
+   * `waitUntil` so the runtime is not frozen while events sit in the buffer.
+   */
+  settled: () => Promise<void>
   readonly pending: number
 }
 
@@ -32,6 +38,12 @@ export interface PipelineDrainFn<T> {
  * Create a drain pipeline that batches events, retries on failure, and manages buffer overflow.
  *
  * Returns a higher-order function: pass your drain adapter to get a hook-compatible function.
+ *
+ * Adapter drains built with `defineDrain` / `defineHttpDrain` are unwrapped to
+ * their throwing `raw` variant, so `retry` and `onDropped` observe delivery
+ * failures and the pipeline owns retries alone. On serverless runtimes,
+ * register `settled()` with `waitUntil` (the framework integrations do this
+ * automatically) so buffered events are delivered before the instance freezes.
  *
  * @example
  * ```ts
@@ -89,9 +101,24 @@ export function createDrainPipeline<T = unknown>(options?: DrainPipelineOptions<
   }
 
   return (drain: (batch: T[]) => void | Promise<void>): PipelineDrainFn<T> => {
+    // Drains built with defineDrain/defineHttpDrain swallow failures so they
+    // never break a request. Their `raw` variant rejects instead — use it so
+    // retry and onDropped observe real failures and own them alone.
+    const rawDrain = (drain as { raw?: unknown }).raw
+    const send = typeof rawDrain === 'function'
+      ? rawDrain as (batch: T[]) => void | Promise<void>
+      : drain
     const buffer: T[] = []
     let timer: ReturnType<typeof setTimeout> | null = null
     let activeFlush: Promise<void> | null = null
+    let settleWaiters: Array<() => void> = []
+
+    function notifySettled(): void {
+      if (buffer.length > 0 || activeFlush || settleWaiters.length === 0) return
+      const waiters = settleWaiters
+      settleWaiters = []
+      for (const resolve of waiters) resolve()
+    }
 
     function clearTimer(): void {
       if (timer !== null) {
@@ -130,7 +157,7 @@ export function createDrainPipeline<T = unknown>(options?: DrainPipelineOptions<
       let lastError: Error | undefined
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
-          await drain(batch)
+          await send(batch)
           return
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error))
@@ -139,7 +166,11 @@ export function createDrainPipeline<T = unknown>(options?: DrainPipelineOptions<
           }
         }
       }
-      onDropped?.(batch, lastError)
+      if (onDropped) {
+        onDropped(batch, lastError)
+      } else {
+        console.error(`[evlog/pipeline] Dropped ${batch.length} event(s) after ${maxAttempts} attempt(s):`, lastError)
+      }
     }
 
     async function drainBuffer(): Promise<void> {
@@ -157,6 +188,8 @@ export function createDrainPipeline<T = unknown>(options?: DrainPipelineOptions<
           startFlush()
         } else if (buffer.length > 0) {
           scheduleFlush()
+        } else {
+          notifySettled()
         }
       })
     }
@@ -190,10 +223,19 @@ export function createDrainPipeline<T = unknown>(options?: DrainPipelineOptions<
           await sendWithRetry(batch)
         }
       }
+      notifySettled()
+    }
+
+    function settled(): Promise<void> {
+      if (buffer.length === 0 && !activeFlush) return Promise.resolve()
+      return new Promise<void>((resolve) => {
+        settleWaiters.push(resolve)
+      })
     }
 
     const hookFn = push as PipelineDrainFn<T>
     hookFn.flush = flush
+    hookFn.settled = settled
     Object.defineProperty(hookFn, 'pending', {
       get: () => buffer.length,
       enumerable: true,

--- a/packages/evlog/src/shared/drain.ts
+++ b/packages/evlog/src/shared/drain.ts
@@ -12,6 +12,30 @@ export interface DrainOptions<TConfig> {
   /** Return `null` to skip draining (e.g. missing API key in dev). */
   resolve: () => TConfig | null | Promise<TConfig | null>
   send: (events: WideEvent[], config: TConfig) => Promise<void>
+  /**
+   * Variant of `send` used by {@link DrainFn.raw}. Defaults to `send`. HTTP
+   * drains use it to skip internal retries when the caller owns retrying.
+   */
+  rawSend?: (events: WideEvent[], config: TConfig) => Promise<void>
+}
+
+/**
+ * Drain callback returned by {@link defineDrain} / {@link defineHttpDrain}.
+ *
+ * Calling it delivers the events and swallows failures (logged with the drain
+ * name), so a failing drain never breaks the request pipeline. `raw` is the
+ * throwing variant for callers that own failure handling themselves.
+ */
+export interface DrainFn {
+  (ctx: DrainContext | DrainContext[]): Promise<void>
+  /**
+   * Deliver the events and reject on failure. Skips the drain's internal
+   * retries unless retries are explicitly configured, so a wrapping layer
+   * owns them. `createDrainPipeline` picks this up automatically: its `retry`
+   * and `onDropped` options observe real failures instead of the swallowing
+   * wrapper.
+   */
+  raw: (ctx: DrainContext | DrainContext[]) => Promise<void>
 }
 
 /**
@@ -29,20 +53,26 @@ export interface DrainOptions<TConfig> {
  * }
  * ```
  */
-export function defineDrain<TConfig>(options: DrainOptions<TConfig>): (ctx: DrainContext | DrainContext[]) => Promise<void> {
-  return async (ctx: DrainContext | DrainContext[]) => {
+export function defineDrain<TConfig>(options: DrainOptions<TConfig>): DrainFn {
+  async function deliver(ctx: DrainContext | DrainContext[], send: DrainOptions<TConfig>['send']): Promise<void> {
     const contexts = Array.isArray(ctx) ? ctx : [ctx]
     if (contexts.length === 0) return
 
     const config = await options.resolve()
     if (!config) return
 
+    await send(contexts.map(c => c.event), config)
+  }
+
+  const drain = (async (ctx: DrainContext | DrainContext[]) => {
     try {
-      await options.send(contexts.map(c => c.event), config)
+      await deliver(ctx, options.send)
     } catch (error) {
       console.error(`[evlog/${options.name}] Failed to send events:`, error)
     }
-  }
+  }) as DrainFn
+  drain.raw = ctx => deliver(ctx, options.rawSend ?? options.send)
+  return drain
 }
 
 export interface HttpDrainRequest {
@@ -135,11 +165,9 @@ export async function sendEncodedDrainRequest(
  * }
  * ```
  */
-export function defineHttpDrain<TConfig>(options: HttpDrainOptions<TConfig>): (ctx: DrainContext | DrainContext[]) => Promise<void> {
-  return defineDrain<TConfig>({
-    name: options.name,
-    resolve: options.resolve,
-    send: async (events, config) => {
+export function defineHttpDrain<TConfig>(options: HttpDrainOptions<TConfig>): DrainFn {
+  function buildSend(fallbackRetries?: number) {
+    return async (events: WideEvent[], config: TConfig): Promise<void> => {
       if (events.length === 0) return
       const request = options.encode(events, config)
       if (!request) return
@@ -149,7 +177,7 @@ export function defineHttpDrain<TConfig>(options: HttpDrainOptions<TConfig>): (c
         ?? DEFAULT_HTTP_TIMEOUT
       const retries = options.resolveRetries?.(config)
         ?? (config as { retries?: number }).retries
-        ?? options.retries
+        ?? fallbackRetries
       await httpPost({
         url: request.url,
         headers: request.headers,
@@ -159,6 +187,14 @@ export function defineHttpDrain<TConfig>(options: HttpDrainOptions<TConfig>): (c
         label: options.label ?? options.name,
         source: options.name,
       })
-    },
+    }
+  }
+  return defineDrain<TConfig>({
+    name: options.name,
+    resolve: options.resolve,
+    send: buildSend(options.retries),
+    // Raw callers (the pipeline) own retries: single attempt unless the
+    // config sets retries explicitly.
+    rawSend: buildSend(0),
   })
 }

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -211,6 +211,14 @@ export async function runEnrichAndDrain(
     const drainPromise = Promise.all(tasks)
     if (options.waitUntil) {
       extendDeferredDrain(drainPromise, options.waitUntil)
+      // A pipeline drain buffers and returns immediately; extend the runtime's
+      // lifetime until the buffered batch is delivered, not just until push().
+      if (hasUserDrain) {
+        const { settled } = drain as { settled?: () => Promise<void> }
+        if (typeof settled === 'function') {
+          extendDeferredDrain(settled(), options.waitUntil)
+        }
+      }
       return
     }
     await drainPromise

--- a/packages/evlog/test/core/middleware.test.ts
+++ b/packages/evlog/test/core/middleware.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DrainContext } from '../../src/types'
 import { initLogger } from '../../src/logger'
+import { createDrainPipeline } from '../../src/pipeline'
 import { globallyRedacted } from '../../src/redact'
 import { createMiddlewareLogger } from '../../src/shared/middleware'
 import { defined } from '../helpers/defined'
 import { createPipelineSpies, waitForDrainCalls } from '../helpers/framework'
+import { withFakeTimers } from '../helpers/timers'
 
 describe('createMiddlewareLogger', () => {
   beforeEach(() => {
@@ -459,6 +462,38 @@ describe('createMiddlewareLogger', () => {
       await scheduled
       expect(drain).toHaveBeenCalledOnce()
       expect(drainSettled).toBe(true)
+    })
+
+    it('registers pipeline settled() with waitUntil so buffered batches are delivered', async () => {
+      await withFakeTimers(async () => {
+        const send = vi.fn().mockResolvedValue(undefined)
+        const drain = createDrainPipeline<DrainContext>({ batch: { size: 10, intervalMs: 1000 } })(send)
+        const waitUntil = vi.fn()
+
+        const { finish } = createMiddlewareLogger({
+          method: 'GET',
+          path: '/api/test',
+          drain,
+          waitUntil,
+        })
+
+        await finish({ status: 200 })
+
+        expect(waitUntil).toHaveBeenCalledTimes(2)
+        const [settledPromise] = defined(waitUntil.mock.calls[1], 'settled registration')
+        let delivered = false
+        void (settledPromise as Promise<void>).then(() => {
+          delivered = true
+        })
+
+        await vi.advanceTimersByTimeAsync(0)
+        expect(delivered).toBe(false)
+        expect(send).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(delivered).toBe(true)
+        expect(send).toHaveBeenCalledTimes(1)
+      })
     })
 
     it('still awaits enrich before registering waitUntil drain', async () => {

--- a/packages/evlog/test/core/pipeline.test.ts
+++ b/packages/evlog/test/core/pipeline.test.ts
@@ -507,6 +507,31 @@ describe('createDrainPipeline', () => {
       expect(drain).toHaveBeenCalledTimes(2)
     })
 
+    it('stays pending while an explicit flush() delivery is in flight', async () => {
+      let resolveDrain!: () => void
+      const drain = vi.fn(() => new Promise<void>((resolve) => {
+        resolveDrain = resolve
+      }))
+      const hook = createDrainPipeline({ batch: { size: 10, intervalMs: 60000 } })(drain)
+
+      hook(createTestContext(1))
+      const flushPromise = hook.flush()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(drain).toHaveBeenCalledTimes(1)
+
+      let resolved = false
+      void hook.settled().then(() => {
+        resolved = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(resolved).toBe(false)
+
+      resolveDrain()
+      await flushPromise
+      await vi.advanceTimersByTimeAsync(0)
+      expect(resolved).toBe(true)
+    })
+
     it('resolves via flush()', async () => {
       const drain = vi.fn().mockResolvedValue(undefined)
       const hook = createDrainPipeline({ batch: { size: 10, intervalMs: 60000 } })(drain)

--- a/packages/evlog/test/core/pipeline.test.ts
+++ b/packages/evlog/test/core/pipeline.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DrainContext } from '../../src/types'
 import { createDrainPipeline } from '../../src/pipeline'
+import { defineDrain } from '../../src/shared/drain'
 import { defined } from '../helpers/defined'
 
 function getBatchArg(call: unknown[]): DrainContext[] {
@@ -388,6 +389,139 @@ describe('createDrainPipeline', () => {
 
     it('throws on NaN batch.size', () => {
       expect(() => createDrainPipeline({ batch: { size: NaN } })).toThrow('batch.size must be a positive finite number')
+    })
+  })
+
+  describe('adapter raw composition', () => {
+    it('uses drain.raw so retries and onDropped observe adapter failures', async () => {
+      const send = vi.fn().mockRejectedValue(new Error('ingest down'))
+      const adapter = defineDrain<{ ok: boolean }>({
+        name: 'unit-test',
+        resolve: () => ({ ok: true }),
+        send,
+      })
+      const onDropped = vi.fn()
+      const hook = createDrainPipeline<DrainContext>({
+        batch: { size: 1, intervalMs: 60000 },
+        retry: { maxAttempts: 2, initialDelayMs: 10 },
+        onDropped,
+      })(adapter)
+
+      hook(createTestContext(1))
+      await vi.runAllTimersAsync()
+
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(onDropped).toHaveBeenCalledTimes(1)
+      const [batch, error] = defined(onDropped.mock.calls[0], 'onDropped call')
+      expect(batch).toHaveLength(1)
+      expect((error as Error).message).toContain('ingest down')
+    })
+
+    it('delivers through drain.raw on success', async () => {
+      const send = vi.fn().mockResolvedValue(undefined)
+      const adapter = defineDrain<{ ok: boolean }>({
+        name: 'unit-test',
+        resolve: () => ({ ok: true }),
+        send,
+      })
+      const hook = createDrainPipeline<DrainContext>({ batch: { size: 2, intervalMs: 60000 } })(adapter)
+
+      hook(createTestContext(1))
+      hook(createTestContext(2))
+      await vi.runAllTimersAsync()
+
+      expect(send).toHaveBeenCalledTimes(1)
+      const [events] = defined(send.mock.calls[0], 'send call')
+      expect(events).toHaveLength(2)
+    })
+
+    it('logs dropped batches when no onDropped is provided', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const drain = vi.fn().mockRejectedValue(new Error('boom'))
+      const hook = createDrainPipeline<DrainContext>({
+        batch: { size: 1, intervalMs: 60000 },
+        retry: { maxAttempts: 1 },
+      })(drain)
+
+      hook(createTestContext(1))
+      await vi.runAllTimersAsync()
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[evlog/pipeline] Dropped 1 event(s) after 1 attempt(s)'),
+        expect.any(Error),
+      )
+      errorSpy.mockRestore()
+    })
+  })
+
+  describe('settled()', () => {
+    it('resolves immediately when nothing is buffered', async () => {
+      const drain = vi.fn().mockResolvedValue(undefined)
+      const hook = createDrainPipeline({ batch: { size: 10, intervalMs: 5000 } })(drain)
+
+      let resolved = false
+      void hook.settled().then(() => {
+        resolved = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(resolved).toBe(true)
+      expect(drain).not.toHaveBeenCalled()
+    })
+
+    it('resolves once the interval flush delivers buffered events', async () => {
+      const drain = vi.fn().mockResolvedValue(undefined)
+      const hook = createDrainPipeline({ batch: { size: 10, intervalMs: 5000 } })(drain)
+
+      hook(createTestContext(1))
+      let resolved = false
+      void hook.settled().then(() => {
+        resolved = true
+      })
+
+      await vi.advanceTimersByTimeAsync(4999)
+      expect(resolved).toBe(false)
+      expect(drain).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(resolved).toBe(true)
+      expect(drain).toHaveBeenCalledTimes(1)
+    })
+
+    it('resolves after a failing batch is dropped', async () => {
+      const drain = vi.fn().mockRejectedValue(new Error('boom'))
+      const hook = createDrainPipeline({
+        batch: { size: 1, intervalMs: 60000 },
+        retry: { maxAttempts: 2, initialDelayMs: 10 },
+        onDropped: vi.fn(),
+      })(drain)
+
+      hook(createTestContext(1))
+      let resolved = false
+      void hook.settled().then(() => {
+        resolved = true
+      })
+
+      await vi.runAllTimersAsync()
+      expect(resolved).toBe(true)
+      expect(drain).toHaveBeenCalledTimes(2)
+    })
+
+    it('resolves via flush()', async () => {
+      const drain = vi.fn().mockResolvedValue(undefined)
+      const hook = createDrainPipeline({ batch: { size: 10, intervalMs: 60000 } })(drain)
+
+      hook(createTestContext(1))
+      let resolved = false
+      void hook.settled().then(() => {
+        resolved = true
+      })
+
+      await hook.flush()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(resolved).toBe(true)
+      expect(drain).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/evlog/test/toolkit/toolkit.test.ts
+++ b/packages/evlog/test/toolkit/toolkit.test.ts
@@ -517,6 +517,38 @@ describe('defineHttpDrain', () => {
     await expect(drain(drainCtx())).resolves.toBeUndefined()
     expect(console.error).toHaveBeenCalled()
   })
+
+  it('raw rejects on HTTP failure with a single attempt', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response('boom', { status: 500 }))))
+    const drain = defineHttpDrain<{ apiKey: string }>({
+      name: 'unit-test',
+      resolve: () => ({ apiKey: 'k' }),
+      encode: () => ({ url: 'https://x.test', headers: {}, body: '{}' }),
+    })
+    await expect(drain.raw(drainCtx())).rejects.toThrow('unit-test API error: 500')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('raw honors explicitly configured retries', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response('boom', { status: 500 }))))
+    const drain = defineHttpDrain<{ apiKey: string; retries?: number }>({
+      name: 'unit-test',
+      resolve: () => ({ apiKey: 'k', retries: 1 }),
+      encode: () => ({ url: 'https://x.test', headers: {}, body: '{}' }),
+    })
+    await expect(drain.raw(drainCtx())).rejects.toThrow()
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('raw skips when resolve returns null', async () => {
+    const drain = defineHttpDrain<{ apiKey: string }>({
+      name: 'unit-test',
+      resolve: () => null,
+      encode: () => ({ url: 'https://x.test', headers: {}, body: '{}' }),
+    })
+    await expect(drain.raw(drainCtx())).resolves.toBeUndefined()
+    expect(fetch).not.toHaveBeenCalled()
+  })
 })
 
 describe('defineEvlog / toLoggerConfig / toMiddlewareOptions', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -799,6 +799,16 @@ importers:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
+  examples/repro:
+    dependencies:
+      evlog:
+        specifier: workspace:*
+        version: link:../../packages/evlog
+    devDependencies:
+      tsx:
+        specifier: ^4.20.7
+        version: 4.23.1
+
   examples/solidstart:
     dependencies:
       '@solidjs/router':
@@ -12047,6 +12057,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
Omit the scope when the change is cross-cutting or repo-wide. Use a scope only
to point at one subsystem; the whole monorepo is `evlog`, so `evlog` is not a
scope.

- ai (AI SDK integration)
- axiom (Axiom drain adapter)
- bench (benchmarks)
- better-auth (Better Auth integration)
- better-stack (Better Stack drain adapter)
- clickhouse (ClickHouse drain adapter)
- cli (`@evlog/cli` package)
- core (logger, pipeline, error, redact, catalog internals)
- datadog (Datadog drain adapter)
- deps (the dependencies)
- docs (the documentation site)
- dx (developer experience improvements)
- elysia (Elysia plugin)
- evals (Evi eval suite)
- eve (eve agent integration)
- evi (Evi agent)
- express (Express middleware)
- fastify (Fastify plugin)
- fs (File System drain adapter)
- hono (Hono middleware)
- hyperdx (HyperDX drain adapter)
- loki (Grafana Loki drain adapter)
- nestjs (NestJS middleware)
- next (Next.js integration)
- nitro (Nitro plugin)
- nuxt (Nuxt module)
- orpc (oRPC integration)
- otlp (OTLP drain adapter)
- playground (the playground app)
- posthog (PostHog drain adapter)
- react-router (React Router integration)
- release (release workflow / publishing)
- repo (the repository: tooling, CI, scripts, root config)
- sentry (Sentry drain adapter)
- stream (in-process stream + stream server)
- sveltekit (SvelteKit integration)
- tanstack-start (TanStack Start integration)
- telemetry (`@evlog/telemetry` package)
- vite (Vite plugin)
- workers (Cloudflare Workers adapter)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `settled()` to wait for buffered events to be delivered or dropped.
  * Improved serverless runtime handling during batching delays.
  * Added reliable drain failure handling for pipeline-managed retries.

* **Bug Fixes**
  * Pipeline retries and dropped-event reporting now respond to actual delivery failures.
  * Exhausted batches are logged when no drop handler is configured.
  * Prevented duplicate retry attempts across pipeline and HTTP drains.

* **Documentation**
  * Expanded guidance for serverless integrations, custom drains, retries, batching, and shutdown handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->