### PR TITLE
feat(cli): wire hono in evlog init

### DIFF
--- a/.changeset/hono-init.md
+++ b/.changeset/hono-init.md
@@ -1,0 +1,5 @@
+---
+"@evlog/cli": minor
+---
+
+`evlog init` wires Hono projects. It creates `src/evlog.ts` with `initLogger` and a configured `evlog()` middleware export: drains and enrichers land in the middleware options, sampling in `initLogger`. Registering the middleware stays yours, so init prints the `app.use(evlogMiddleware)` line to paste. Hono joins the framework prompt, `--framework hono`, and init telemetry.

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -195,6 +195,26 @@ Writes the Nitro v3 config with `experimental.asyncContext` enabled. Without it 
 
 The `evlogErrorHandler` middleware on your root route is a manual step: `__root.tsx` is a component file, and splicing into it is guesswork.
 
+### Hono
+
+Creates `src/evlog.ts` (or `evlog.ts` when there is no `src/`) with `initLogger` and a configured middleware export, since Hono has no config file to append to. Drains and enrichers land in the middleware options, sampling in `initLogger`.
+
+Registering it stays yours: your app entry is application code, so `init` prints the two lines to paste.
+
+```typescript [src/evlog.ts]
+import { initLogger } from 'evlog'
+import { evlog } from 'evlog/hono'
+
+initLogger({
+  env: { service: 'api' },
+})
+
+/** Register once, before your routes: `app.use(evlogMiddleware)`. */
+export const evlogMiddleware = evlog({
+  // drains and enrichers, from your answers
+})
+```
+
 ## Destinations
 
 Two questions rather than one list: nobody sends local development traffic to Axiom, and nobody reads production logs off the box's filesystem. `--drain` sets the development drain (`fs` or `none`); `--prod-drain` takes one or more hosted destinations.
@@ -319,7 +339,7 @@ The directory it writes to is `.evlog/logs`, and evlog gitignores it on first wr
 | Flag | What it does |
 | --- | --- |
 | `--yes`, `-y` | Skip every question and take the defaults |
-| `--framework <name>` | Override detection (`nuxt`, `nitro`, `next`, `tanstack-start`) |
+| `--framework <name>` | Override detection (`nuxt`, `nitro`, `next`, `tanstack-start`, `hono`) |
 | `--service <name>` | Service name on every wide event (default: your package name, unscoped) |
 | `--drain <id>` | Development drain: `fs` (default) or `none` |
 | `--prod-drain <a,b>` | Production destinations — see the table above |

--- a/apps/docs/skills/analyze-logs/SKILL.md
+++ b/apps/docs/skills/analyze-logs/SKILL.md
@@ -52,7 +52,7 @@ Files are named by date: `2026-03-14.jsonl`. Start with the most recent file.
 
 Before wiring a new drain, you can try `npx @evlog/cli doctor --json`, which checks whether `evlog` is installed and whether a local `.evlog/logs` drain already exists (read-only). Optional; skip if the CLI is unavailable.
 
-The file system drain may not be enabled. On Nuxt, Nitro, Next.js, or TanStack Start, the fastest path is the CLI, which detects the framework and wires the fs drain (its default dev drain) in one pass:
+The file system drain may not be enabled. On Nuxt, Nitro, Next.js, TanStack Start, or Hono, the fastest path is the CLI, which detects the framework and wires the fs drain (its default dev drain) in one pass:
 
 ```bash
 npx @evlog/cli init --dry-run --yes   # preview first

--- a/apps/docs/skills/review-logging-patterns/SKILL.md
+++ b/apps/docs/skills/review-logging-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-logging-patterns
-description: Review code for logging patterns and suggest evlog adoption. Optionally use @evlog/cli (`evlog init` to wire evlog, `evlog agents` to write the conventions into AGENTS.md, `evlog map` to score entry-point coverage, `--baseline` to gate regressions in CI) on Nuxt, Nitro, Next.js, and TanStack Start; `evlog map` also scans Hono. Guides setup on those plus SvelteKit, React Router, NestJS, Express, Fastify, Elysia, oRPC, Cloudflare Workers, AWS Lambda, Astro, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, HyperDX, PostHog, Sentry, Better Stack, Datadog, Loki, ClickHouse, NuxtHub, Memory), sampling, enrichers, and AI SDK integration.
+description: Review code for logging patterns and suggest evlog adoption. Optionally use @evlog/cli (`evlog init` to wire evlog, `evlog agents` to write the conventions into AGENTS.md, `evlog map` to score entry-point coverage, `--baseline` to gate regressions in CI) on Nuxt, Nitro, Next.js, TanStack Start, and Hono. Guides setup on those plus SvelteKit, React Router, NestJS, Express, Fastify, Elysia, oRPC, Cloudflare Workers, AWS Lambda, Astro, and standalone TypeScript. Detects console.log spam, unstructured errors, and missing context. Covers wide events, structured errors, drain adapters (Axiom, OTLP, HyperDX, PostHog, Sentry, Better Stack, Datadog, Loki, ClickHouse, NuxtHub, Memory), sampling, enrichers, and AI SDK integration.
 license: MIT
 metadata:
   author: HugoRCD
@@ -56,7 +56,7 @@ npm install evlog
 
 ## Use the CLI (recommended on Nuxt, Nitro, Next.js, TanStack Start, Hono)
 
-`@evlog/cli` is a **separate package** from `evlog`, early but worth trying. It reads the project on disk (no traffic, no config). On Nuxt, Nitro, Next.js, and TanStack Start it covers the whole loop: **wire evlog in** (`init`), **score coverage** (`map`), **lock the score in CI** (`--min-score`, `--baseline`). On Hono, `map` and the CI gate work, but `init` has no wiring plan yet: set evlog up with the manual Hono section below, then score with `map`. If the CLI is unavailable, the framework has no adapter yet, or the user declines, continue with the manual sections below; the skill does not depend on it. **Ask before installing anything**; prefer `npx` / `pnpm dlx` for one-shots.
+`@evlog/cli` is a **separate package** from `evlog`, early but worth trying. It reads the project on disk (no traffic, no config). On the five supported frameworks it covers the whole loop: **wire evlog in** (`init`), **score coverage** (`map`), **lock the score in CI** (`--min-score`, `--baseline`). If the CLI is unavailable, the framework has no adapter yet, or the user declines, continue with the manual sections below; the skill does not depend on it. **Ask before installing anything**; prefer `npx` / `pnpm dlx` for one-shots.
 
 ### 1. Setup: `evlog init`
 
@@ -75,7 +75,7 @@ npx @evlog/cli init --yes \
   --sampling medium
 ```
 
-Useful flags: `--framework` (override detection: `nuxt`, `nitro`, `next`, `tanstack-start`), `--prodDrain` (comma-separated: `axiom`, `otlp`, `posthog`, `sentry`, `better-stack`, `datadog`, `hyperdx`), `--extras` (`enrichers`, `pipeline`, `sampling`, `vite`, `error-catalog`, `audit-catalog`, `ai`, `better-auth`), `--enrichers`, `--sampling` (traffic tier: `all`, `low`, `medium`, `high`, `very-high`), `--apps` (monorepo: which workspace packages), `--no-install`. Review the `--dry-run` output with the user before applying. Docs: https://www.evlog.dev/cli/init
+Useful flags: `--framework` (override detection: `nuxt`, `nitro`, `next`, `tanstack-start`, `hono`), `--prodDrain` (comma-separated: `axiom`, `otlp`, `posthog`, `sentry`, `better-stack`, `datadog`, `hyperdx`), `--extras` (`enrichers`, `pipeline`, `sampling`, `vite`, `error-catalog`, `audit-catalog`, `ai`, `better-auth`), `--enrichers`, `--sampling` (traffic tier: `all`, `low`, `medium`, `high`, `very-high`), `--apps` (monorepo: which workspace packages), `--no-install`. Review the `--dry-run` output with the user before applying. Docs: https://www.evlog.dev/cli/init
 
 ### 2. Score: `evlog map`
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -48,7 +48,7 @@ export default defineEvlogCommand('init', {
   skipHeader: (ctx, args) => args.json !== true && args.yes !== true && canPrompt(ctx),
   args: {
     cwd: { type: 'string', description: 'Project directory (default: current)' },
-    framework: { type: 'string', description: 'Override framework detection (nuxt, nitro, next, tanstack-start)' },
+    framework: { type: 'string', description: 'Override framework detection (nuxt, nitro, next, tanstack-start, hono)' },
     service: { type: 'string', description: 'Service name on every wide event (default: package name)' },
     drain: { type: 'string', description: 'Development sink: fs (default) or none' },
     prodDrain: { type: 'string', description: 'Production destinations, comma-separated: axiom, otlp, posthog, sentry, better-stack, datadog, hyperdx' },

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -80,8 +80,8 @@ export const cliErrors = defineErrorCatalog('cli', {
     status: 400,
     message: ({ value }: { value: string }) =>
       `Unknown --framework "${value}"`,
-    why: 'init only knows how to wire nuxt, nitro, next, and tanstack-start',
-    fix: 'Pass one of: nuxt, nitro, next, tanstack-start — or omit it and let detection decide',
+    why: 'init only knows how to wire nuxt, nitro, next, tanstack-start, and hono',
+    fix: 'Pass one of: nuxt, nitro, next, tanstack-start, hono — or omit it and let detection decide',
     link: 'https://evlog.dev/cli/init',
     tags: ['init'],
   },

--- a/packages/cli/src/lib/init/frameworks.ts
+++ b/packages/cli/src/lib/init/frameworks.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
-import { cliErrors } from '../errors'
 import type { Framework } from '../map/types'
 import { findDestination, findEnricher, findSamplingPreset } from './catalog'
 import type { DrainId, EnricherId, ExtraId, SamplingProfile } from './catalog'
@@ -48,11 +47,11 @@ export interface WiringPlan {
 /**
  * Frameworks `init` can wire — the ones with a `frameworkPlan` case.
  *
- * `map` scans more (hono has an adapter but no wiring plan yet): every init
- * surface (flag parsing, prompt, workspace targets, telemetry) reads this list
- * so a map-only framework is refused cleanly instead of reaching the planner.
+ * `map` adapters can land ahead of init wiring: every init surface (flag
+ * parsing, prompt, workspace targets, telemetry) reads this list so a map-only
+ * framework is refused cleanly instead of reaching the planner.
  */
-export const INIT_FRAMEWORKS = ['nuxt', 'nitro', 'next', 'tanstack-start'] as const satisfies readonly Framework[]
+export const INIT_FRAMEWORKS = ['nuxt', 'nitro', 'next', 'tanstack-start', 'hono'] as const satisfies readonly Framework[]
 
 export function isInitFramework(framework: Framework): boolean {
   return (INIT_FRAMEWORKS as readonly Framework[]).includes(framework)
@@ -553,8 +552,12 @@ export const { register, onRequestError } = defineNodeInstrumentation({
 `
 }
 
-/** The pieces of a Next.js `lib/evlog.ts` — shared by the create and patch paths. */
-interface NextFactoryParts {
+/**
+ * The pieces of a generated evlog config file — shared by Next's `lib/evlog.ts`
+ * (create and patch paths) and Hono's `src/evlog.ts`, which are both plain
+ * TypeScript rather than a framework config.
+ */
+interface FactoryParts {
   imports: string[]
   /** Statements that go above `createEvlog`. */
   preamble: string
@@ -562,7 +565,7 @@ interface NextFactoryParts {
   options: string[]
 }
 
-function nextFactoryParts(input: WiringInput): NextFactoryParts {
+function factoryParts(input: WiringInput): FactoryParts {
   const dev = input.devDrain === 'none' ? null : findDestination(input.devDrain) ?? null
   const prod = input.prodDrains.map(id => findDestination(id)).filter(Boolean) as NonNullable<ReturnType<typeof findDestination>>[]
   const batched = input.extras.includes('pipeline') && prod.length > 0
@@ -593,7 +596,7 @@ function nextFactoryParts(input: WiringInput): NextFactoryParts {
   const wrap = (factory: string) => batched ? `pipeline(${factory})` : factory
   const options: string[] = []
 
-  // Next has no `import.meta.dev`, so the split is on NODE_ENV.
+  // Neither Next nor Hono has `import.meta.dev`, so the split is on NODE_ENV.
   if (dev && prod.length > 0) {
     blocks.push(`const drains = process.env.NODE_ENV === 'production'\n  ? [${prod.map(d => wrap(d.factory!)).join(', ')}]\n  : [${dev.factory}]`)
     options.push('  drain: async ctx => void await Promise.all(drains.map(drain => drain(ctx))),')
@@ -620,7 +623,7 @@ function nextFactoryParts(input: WiringInput): NextFactoryParts {
 }
 
 function nextLibTemplate(input: WiringInput): string {
-  const { imports, preamble, options } = nextFactoryParts(input)
+  const { imports, preamble, options } = factoryParts(input)
   const all = [`import { createEvlog } from 'evlog/next'`, ...imports]
 
   return `${all.join('\n')}
@@ -638,7 +641,7 @@ ${options.join('\n')}${options.length > 0 ? '\n' : ''}})
  * barrel or a computed config gets the snippet to paste instead.
  */
 function patchNextLib(plan: WiringPlan, input: WiringInput, path: string, relativePath: string): void {
-  const { imports, preamble, options } = nextFactoryParts(input)
+  const { imports, preamble, options } = factoryParts(input)
   if (options.length === 0) {
     plan.already.push(`${relativePath} already exists`)
     return
@@ -794,6 +797,9 @@ function catalogDir(input: WiringInput): string {
     return useSrc ? join('src', 'lib') : 'lib'
   }
   if (input.framework === 'tanstack-start') return join('src', 'lib')
+  if (input.framework === 'hono') {
+    return existsSync(join(input.root, 'src')) ? join('src', 'lib') : 'lib'
+  }
   return join('server', 'utils')
 }
 
@@ -907,6 +913,49 @@ export const GET = withEvlog(async () => {
   return plan
 }
 
+/* ── hono ───────────────────────────────────────────────────────────────── */
+
+function honoEvlogTemplate(input: WiringInput): string {
+  const { imports, preamble, options } = factoryParts(input)
+  /* Hono splits the surface: sampling belongs to `initLogger`, drains and
+     enrichers are middleware options. */
+  const sampling = options.filter(option => option.trimStart().startsWith('sampling:'))
+  const middleware = options.filter(option => !sampling.includes(option))
+  const head = [`import { initLogger } from 'evlog'`, `import { evlog } from 'evlog/hono'`, ...imports]
+
+  return `${head.join('\n')}
+
+initLogger({
+  env: { service: '${input.service}' },
+${sampling.join('\n')}${sampling.length > 0 ? '\n' : ''}})
+${preamble}
+/** Register once, before your routes: \`app.use(evlogMiddleware)\`. */
+export const evlogMiddleware = evlog(${middleware.length > 0 ? `{\n${middleware.join('\n')}\n}` : ''})
+`
+}
+
+function planHono(input: WiringInput): WiringPlan {
+  const plan: WiringPlan = { actions: [], manual: [], already: [] }
+  const useSrc = existsSync(join(input.root, 'src'))
+  const relativePath = useSrc ? join('src', 'evlog.ts') : 'evlog.ts'
+  addFile(plan, input, relativePath, honoEvlogTemplate(input))
+
+  const entry = useSrc ? join('src', 'index.ts') : 'index.ts'
+  plan.manual.push({
+    title: 'Register the middleware on your app',
+    file: entry,
+    snippet: `import { Hono } from 'hono'
+import type { EvlogVariables } from 'evlog/hono'
+import { evlogMiddleware } from './evlog'
+
+const app = new Hono<EvlogVariables>()
+app.use(evlogMiddleware)`,
+    reason: `${entry} is your application file, and splicing a middleware into it is guesswork`,
+  })
+
+  return plan
+}
+
 /** Build the file plan for a framework. Pure: reads the project, writes nothing. */
 export function planWiring(input: WiringInput): WiringPlan {
   // Applied once here rather than in each planner, where one would be forgotten.
@@ -919,9 +968,7 @@ function frameworkPlan(input: WiringInput): WiringPlan {
     case 'nitro':
     case 'tanstack-start': return planNitro(input)
     case 'next': return planNext(input)
-    /* map-only framework — the INIT_FRAMEWORKS guard refuses it before any
-       prompt; thrown here too so the planner can never return undefined. */
-    case 'hono': throw cliErrors.INIT_FRAMEWORK_UNSUPPORTED({ framework: input.framework })
+    case 'hono': return planHono(input)
   }
   /* A new Framework member fails to compile here until init decides on a plan. */
   return input.framework satisfies never

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -602,26 +602,81 @@ describe('sampling tiers', () => {
   })
 })
 
-describe('runInit — map-only frameworks', () => {
-  it('refuses a hono project cleanly instead of reaching the planner', async () => {
+describe('planWiring — hono', () => {
+  it('creates src/evlog.ts with the configured middleware and asks for the app.use line', async () => {
+    const root = await project({
+      'package.json': '{"name":"shop","dependencies":{"hono":"^4.0.0"}}',
+      'src/index.ts': 'import { Hono } from \'hono\'\nconst app = new Hono()\nexport default app\n',
+    })
+
+    const plan = planWiring({ root, framework: 'hono', service: 'api', ...wiring(), nitroMajor: 3 })
+    const file = plan.actions.find(action => action.relative === join('src', 'evlog.ts'))!
+
+    expect(file.contents).toContain(`import { evlog } from 'evlog/hono'`)
+    expect(file.contents).toContain(`initLogger({\n  env: { service: 'api' },\n})`)
+    expect(file.contents).toContain('export const evlogMiddleware = evlog(')
+    expect(file.contents).toContain('createFsDrain')
+    expect(plan.manual.map(step => step.title)).toContain('Register the middleware on your app')
+    expect(plan.manual[0]?.snippet).toContain('app.use(evlogMiddleware)')
+  })
+
+  it('puts sampling in initLogger and drains on the middleware', async () => {
+    const root = await project({
+      'package.json': '{"name":"shop","dependencies":{"hono":"^4.0.0"}}',
+      'src/index.ts': 'export {}\n',
+    })
+
+    const plan = planWiring({
+      root,
+      framework: 'hono',
+      service: 'api',
+      ...wiring({ prodDrains: ['axiom'], extras: ['sampling'], sampling: 'medium' }),
+      nitroMajor: 3,
+    })
+    const file = plan.actions.find(action => action.relative === join('src', 'evlog.ts'))!
+    const [initBlock] = file.contents.split('export const evlogMiddleware')
+
+    expect(initBlock).toContain('sampling:')
+    expect(file.contents.split('evlogMiddleware = evlog(')[1]).toContain('drain:')
+    expect(file.contents).toContain('createAxiomDrain')
+  })
+
+  it('falls back to the package root when there is no src directory', async () => {
+    const root = await project({
+      'package.json': '{"name":"shop","dependencies":{"hono":"^4.0.0"}}',
+      'index.ts': 'export {}\n',
+    })
+
+    const plan = planWiring({ root, framework: 'hono', service: 'api', ...wiring(), nitroMajor: 3 })
+
+    expect(plan.actions.map(action => action.relative)).toContain('evlog.ts')
+    expect(plan.manual[0]?.file).toBe('index.ts')
+  })
+
+  it('reports an existing evlog.ts instead of overwriting it', async () => {
+    const root = await project({
+      'package.json': '{"name":"shop","dependencies":{"hono":"^4.0.0"}}',
+      'src/evlog.ts': 'export const evlogMiddleware = null\n',
+    })
+
+    const plan = planWiring({ root, framework: 'hono', service: 'api', ...wiring(), nitroMajor: 3 })
+
+    expect(plan.actions.map(action => action.relative)).not.toContain(join('src', 'evlog.ts'))
+    expect(plan.already.some(line => line.includes('evlog.ts'))).toBe(true)
+  })
+})
+
+describe('runInit — hono', () => {
+  it('wires a hono project end to end', async () => {
     const cwd = await project({
       'package.json': '{"name":"shop","dependencies":{"hono":"^4.0.0"}}',
       'src/index.ts': 'import { Hono } from \'hono\'\nconst app = new Hono()\nexport default app\n',
     })
 
-    await expect(runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true }))
-      .rejects.toThrow(/init cannot wire hono yet/)
-  })
+    const result = await runInit(fakeContext(cwd), undefined, { agentGuide: false, install: false, yes: true })
 
-  it('throws from the planner backstop instead of returning undefined', () => {
-    const plan = () => planWiring({
-      root: '/tmp/nowhere',
-      framework: 'hono',
-      service: 'shop',
-      ...wiring(),
-      nitroMajor: 3,
-    })
-
-    expect(plan).toThrow(/init cannot wire hono yet/)
+    expect(result.answers.framework).toBe('hono')
+    expect(result.written.map(action => action.relative)).toContain(join('src', 'evlog.ts'))
+    expect(await readFile(join(cwd, 'src', 'evlog.ts'), 'utf8')).toContain('export const evlogMiddleware')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Stacked on #629 — completes the Hono CLI story that PR opens.

### 📚 Description

`evlog init` gains a Hono wiring plan, so the base PR's clean refusal (`INIT_FRAMEWORK_UNSUPPORTED`) no longer fires and the CLI covers the whole loop (init → map → CI gate) on five frameworks.

- `planHono` creates `src/evlog.ts` (or `evlog.ts` without a `src/`) with `initLogger({ env: { service } })` and a configured `evlog()` middleware export. Drains and enrichers go in the middleware options, sampling in `initLogger`. It reuses the shared `factoryParts` builder (renamed from `nextFactoryParts`) that already powers Next's `lib/evlog.ts`.
- Registering the middleware is a manual step (`app.use(evlogMiddleware)` snippet), matching the Next/TanStack doctrine of never splicing into application files.
- `hono` joins `INIT_FRAMEWORKS`, so the prompt, `--framework`, workspace targets, and init telemetry pick it up from the single list.
- Catalog extras land in `src/lib/` for Hono projects.
- Docs: real `### Hono` section on the init page; the skills go back to "five supported frameworks" for the whole loop.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.