### PR TITLE
feat(cli): cover hono in the sandbox and run its smoke in ci

### DIFF
--- a/.agents/skills/create-map-rule/SKILL.md
+++ b/.agents/skills/create-map-rule/SKILL.md
@@ -132,7 +132,7 @@ pnpm --filter @evlog/cli run typecheck   # catches REGISTRY/CheckId drift
 pnpm --filter @evlog/cli run test
 ```
 
-Then sanity-check on a real project: `pnpm cli map --no-write` from an example app.
+Then sanity-check on a real project: `pnpm cli:sandbox` builds disposable, unevenly-instrumented apps under `.sandbox/` (one per supported framework, each a git repo), and prints the commands to run against them. `pnpm cli:sandbox --reset` rolls an app back to pristine after an `init` or `map` run; `--smoke` drives the whole non-interactive feature matrix and reports what broke.
 
 ---
 
@@ -150,6 +150,7 @@ Teaching `evlog map` a new framework is a different, heavier change: the adapter
 | 6 | `packages/cli/src/lib/init/` | Decide whether `evlog init` gains the framework too (separate scope of work — flag it explicitly in the PR if not) |
 | 7 | `apps/docs/content/3.cli/2.map.md` + `0.overview.md` | Update the supported-frameworks statements |
 | 8 | `apps/docs/skills/review-logging-patterns/SKILL.md` | Update every "Nuxt, Nitro, Next.js, and TanStack Start" list (frontmatter description + CLI section) — same in `references/code-review.md` and `apps/docs/skills/build-audit-logs/SKILL.md` (Pass 2) and `analyze-logs/SKILL.md` (init suggestion) |
-| 9 | `.changeset/{framework}-map-adapter.md` | Changeset for `"@evlog/cli": minor` |
+| 9 | `scripts/cli-sandbox.mjs` | Add the framework to `APPS` (reuse the map fixture) so `pnpm cli:sandbox` covers it and `--smoke` exercises every CLI command against it |
+| 10 | `.changeset/{framework}-map-adapter.md` | Changeset for `"@evlog/cli": minor` |
 
 Reference implementations: `adapters/nuxt.ts` (shared Nuxt/Nitro), `adapters/next.ts`, `adapters/tanstack-start.ts`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,19 @@ jobs:
       - name: Test evlog with coverage
         run: pnpm --filter evlog run test:coverage
 
+      # The sandbox smoke runs every non-interactive CLI command against a real
+      # app per framework — the end-to-end seam (detect → init → doctor → map →
+      # baseline) that unit tests cover only piecewise. Gated to changes that
+      # can affect it, so a docs-only pull request skips the cost.
+      - name: CLI sandbox smoke
+        if: github.event_name == 'pull_request'
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- packages/cli scripts/cli-sandbox.mjs | grep -q .; then
+            node scripts/cli-sandbox.mjs --smoke
+          else
+            echo "CLI untouched — smoke skipped"
+          fi
+
   examples:
     name: Build examples
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ pnpm run typecheck                 # type-check all packages
 pnpm run docs                      # start docs site
 pnpm run telemetry                 # start the telemetry dashboard (apps/telemetry)
 pnpm telemetry:cli <command>       # run this repo's CLI into that local dashboard (--cwd to target an app)
+pnpm cli:sandbox                   # disposable per-framework apps under .sandbox/ to test the CLI by hand (--reset restores them, --smoke runs the feature matrix)
 pnpm content:lint [path]           # rank the written corpus by content findings (see scripts/content-lint/README.md)
 pnpm content:lint:test             # the scanner's own tests, including its two calibration fixtures
 ```

--- a/scripts/cli-sandbox.mjs
+++ b/scripts/cli-sandbox.mjs
@@ -37,7 +37,7 @@ const cyan = text => paint('36', text)
 /* ── the apps ───────────────────────────────────────────────────────────── */
 
 /**
- * Three of the four come from the `map` test fixtures rather than being written
+ * All but one come from the `map` test fixtures rather than being written
  * again here: they are already realistic apps with deliberately uneven
  * instrumentation, which is exactly what makes a `map` report worth reading.
  * Nitro has no fixture, so it is generated.
@@ -47,6 +47,7 @@ const APPS = [
   { name: 'next', fixture: 'next-app-router', augment: augmentNextApp },
   { name: 'tanstack', fixture: 'tanstack-basic' },
   { name: 'nitro', generate: generateNitroApp },
+  { name: 'hono', fixture: 'hono-basic' },
 ]
 
 /**
@@ -414,7 +415,7 @@ check('init never overwrites, never silently drops a destination', (dir) => {
   expect(readFileSync(join(dir, 'lib/evlog.ts'), 'utf8') === '// pre-existing\n', 'lib/evlog.ts was modified')
   expect(readFileSync(join(dir, 'server/plugins/evlog-drain.ts'), 'utf8') === '// pre-existing\n', 'the drain plugin was modified')
 
-  const landed = payload.written.some(file => /evlog-drain-|lib\/evlog/.test(file.file))
+  const landed = payload.written.some(file => /evlog-drain-|lib\/evlog|(^|\/)evlog\.ts$/.test(file.file))
     || payload.manual.some(step => /destination|factory/i.test(step.title))
   expect(landed, 'Axiom was asked for and went nowhere')
 })


### PR DESCRIPTION
### 🔗 Linked issue

Stacked on #630 (itself on #629). Third layer of the Hono CLI stack.

### 📚 Description

`scripts/cli-sandbox.mjs` already solves "test the CLI against real apps and put them back": the committed base is the `map` fixtures plus generators, the working copies live under the gitignored `.sandbox/`, and each app is its own git repo whose initial commit is the pristine state — `--reset` is a `checkout` + `clean`. This PR makes that workflow cover the new framework and makes it public instead of tribal:

- **Hono joins `APPS`** (reusing the `hono-basic` fixture from #629), so `pnpm cli:sandbox` builds it and `--smoke` drives all 18 non-interactive checks against it — the full matrix passes at 18 × 5. One smoke assertion learned Hono's `src/evlog.ts` shape.
- **CI runs the smoke** as a step of the Test job, gated to pull requests that touch `packages/cli` or the script, so a docs-only PR pays nothing. This is the end-to-end seam (detect → init → doctor → map → baseline) that would have caught the init crash the stack's base PR fixed.
- **The workflow is documented where contributors look**: the `pnpm cli:sandbox` line in the root AGENTS.md commands, and the `create-map-rule` skill now lists the sandbox as an adapter touchpoint and uses it as the verification step.

No changeset: nothing published changes.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.