### PR TITLE
fix(core): keep the data payload on createError errors

### DIFF
--- a/.changeset/error-data-payload.md
+++ b/.changeset/error-data-payload.md
@@ -1,0 +1,7 @@
+---
+"evlog": minor
+---
+
+`createError({ data })` returns an extra payload to the client, merged into the response body's `data` object next to `code`, `why`, `fix`, and `link`. Those four win on a key collision, and anything the client must never see still goes in `internal`. Read it client-side with `parseError(err).data`.
+
+The Nitro and Nuxt error handler no longer drops `data` from errors thrown with h3's `createError`. It now follows Nitro's own rule for what it withholds: the message and `data` of an unhandled error are hidden in production, while a deliberate `createError({ status: 500, message })` keeps both. Development returns the error as thrown, as Nitro does.

--- a/apps/docs/content/1.start/3.installation.md
+++ b/apps/docs/content/1.start/3.installation.md
@@ -87,7 +87,7 @@ After installing the package, follow the setup guide for your framework:
   to: /integrate/frameworks/nuxt
   color: neutral
   ---
-  Module with auto-imported `useLogger`, `createError`, and `parseError`.
+  Module with auto-imported `useLogger` and `parseError`.
   :::
   :::card
   ---

--- a/apps/docs/content/1.start/4.quick-start.md
+++ b/apps/docs/content/1.start/4.quick-start.md
@@ -19,7 +19,7 @@ links:
 This guide covers the core APIs you'll use most often with evlog.
 
 ::callout{icon="i-lucide-sparkles" color="info"}
-In Nuxt, evlog **auto-imports** all functions (`useLogger`, `log`, `createError`, `parseError`). No import statements needed.
+In Nuxt, evlog **auto-imports** `useLogger`, `log`, and `parseError`. `createError` is imported from `evlog`: the auto-imported one is Nuxt's own, and it drops `why`, `fix`, and `link`.
 ::
 
 ::prompt

--- a/apps/docs/content/2.learn/3.structured-errors.md
+++ b/apps/docs/content/2.learn/3.structured-errors.md
@@ -121,7 +121,7 @@ The payload is merged into the response body's `data` object next to `code`, `wh
 
 ```typescript
 const { data } = parseError(error)
-if (data?.retryAfter) scheduleRetry(data.retryAfter as number)
+if (typeof data?.retryAfter === 'number') scheduleRetry(data.retryAfter)
 ```
 
 Those four guidance keys win on a collision, so `data: { code: 'x' }` never overwrites the `code` you passed. This is the same field h3's `createError` uses, and evlog's Nitro error handler forwards it for h3 errors too. Anything the client must never see goes in `internal` instead.

--- a/apps/docs/content/2.learn/3.structured-errors.md
+++ b/apps/docs/content/2.learn/3.structured-errors.md
@@ -97,7 +97,34 @@ throw createError({
 | `fix` | No | Actionable solution |
 | `link` | No | Documentation URL |
 | `cause` | No | Original error (for error chaining) |
+| `data` | No | Extra payload returned to the client (see below) |
 | `internal` | No | Backend-only context (see below) |
+
+## Extra payload for the client (`data`)
+
+`why`, `fix`, and `link` are strings a human reads. When the client needs values it branches on, an order id, a retry deadline, a list of invalid fields, pass them as `data`:
+
+```typescript
+throw createError({
+  code: 'PAYMENT_DECLINED',
+  message: 'Payment could not be completed',
+  status: 402,
+  fix: 'Try another payment method',
+  data: {
+    orderId: 'ord_8x2k',
+    retryAfter: 30,
+  },
+})
+```
+
+The payload is merged into the response body's `data` object next to `code`, `why`, `fix`, and `link`, so the client reads it as one object:
+
+```typescript
+const { data } = parseError(error)
+if (data?.retryAfter) scheduleRetry(data.retryAfter as number)
+```
+
+Those four guidance keys win on a collision, so `data: { code: 'x' }` never overwrites the `code` you passed. This is the same field h3's `createError` uses, and evlog's Nitro error handler forwards it for h3 errors too. Anything the client must never see goes in `internal` instead.
 
 ## Backend-only context (`internal`)
 

--- a/apps/docs/content/3.cli/1.init.md
+++ b/apps/docs/content/3.cli/1.init.md
@@ -147,7 +147,7 @@ Use `--dry-run` first if you would rather see the plan before anything is touche
 
 ### Nuxt
 
-Adds `'evlog/nuxt'` to `modules` and an `evlog` block with your service name. `useLogger`, `createError`, and `parseError` are auto-imported from there.
+Adds `'evlog/nuxt'` to `modules` and an `evlog` block with your service name. `useLogger` and `parseError` are auto-imported from there, and `createError` is imported from `evlog`.
 
 ```typescript [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/apps/docs/content/4.integrate/frameworks/01.nuxt.md
+++ b/apps/docs/content/4.integrate/frameworks/01.nuxt.md
@@ -1,12 +1,12 @@
 ---
 title: Nuxt
-description: Add the Nuxt module and every server route emits one wide event. `useLogger(event)`, `createError` and `parseError` are auto-imported.
+description: Add the Nuxt module and every server route emits one wide event. `useLogger(event)` and `parseError` are auto-imported, `createError` comes from `evlog`.
 navigation:
   title: Nuxt
   icon: i-simple-icons-nuxtdotjs
 ---
 
-evlog provides a first-class Nuxt module with auto-imported `useLogger`, `createError`, and `parseError`. Add it to your config and start logging with zero boilerplate.
+evlog provides a first-class Nuxt module with auto-imported `useLogger` and `parseError`. Add it to your config and start logging with zero boilerplate.
 
 ::prompt
 ---
@@ -23,9 +23,9 @@ Set up evlog in my Nuxt app with wide events and structured errors.
 - Install evlog: pnpm add evlog
 - Add 'evlog/nuxt' to modules in nuxt.config.ts
 - Set evlog.env.service to my app name
-- useLogger, createError, and parseError are auto-imported
+- useLogger and parseError are auto-imported, import createError from 'evlog'
 - Create a server/api route using useLogger(event) and log.set() to build a wide event
-- Throw errors with createError({ message, status, why, fix })
+- Throw errors with createError({ message, status, why, fix }), imported from 'evlog'
 - Wide events are auto-emitted when each request completes
 
 Docs: https://www.evlog.dev/integrate/frameworks/nuxt
@@ -65,7 +65,7 @@ export default defineNuxtConfig({
 })
 ```
 
-That's it. `useLogger`, `createError`, and `parseError` are auto-imported.
+That's it. `useLogger` and `parseError` are auto-imported. `createError` is imported from `evlog`.
 
 ## Wide Events
 
@@ -100,9 +100,11 @@ One request, one log line with all context:
 
 ## Error Handling
 
-`createError` produces structured errors with `why`, `fix`, and `link` fields that help both humans and AI agents understand what went wrong.
+`createError` produces structured errors with `why`, `fix`, and `link` fields that help both humans and AI agents understand what went wrong. Import it from `evlog`: a bare `createError` in a server route is h3's, and h3 drops any field it does not know.
 
 ```typescript [server/api/payment/process.post.ts]
+import { createError } from 'evlog'
+
 export default defineEventHandler(async (event) => {
   const log = useLogger(event)
   const body = await readBody(event)
@@ -124,7 +126,7 @@ export default defineEventHandler(async (event) => {
 ```
 
 ::callout{icon="i-lucide-info" color="info"}
-Nuxt's error handler automatically catches `EvlogError` and returns a structured JSON response with `why`, `fix`, and `link` fields.
+Nuxt's error handler automatically catches `EvlogError` and returns a structured JSON response with `why`, `fix`, and `link` fields. Errors thrown with h3's `createError` keep their `data` payload, as they do without the module.
 ::
 
 ## Configuration

--- a/packages/evlog/src/error.ts
+++ b/packages/evlog/src/error.ts
@@ -1,8 +1,11 @@
-import type { ErrorOptions } from './types'
+import type { ErrorOptions, EvlogErrorData } from './types'
 import { colors, isServer } from './utils'
 
 /** Non-enumerable storage so `JSON.stringify(error)` never exposes internal context */
 const evlogErrorInternalKey = Symbol.for('evlog.error.internal')
+
+/** Non-enumerable storage; the payload reaches the wire through the `data` getter */
+const evlogErrorDataKey = Symbol.for('evlog.error.data')
 
 /**
  * Prototype brand read by {@link EvlogError.isEvlogError}. `instanceof` compares
@@ -78,6 +81,15 @@ export class EvlogError extends Error {
       })
     }
 
+    if (opts.data !== undefined) {
+      Object.defineProperty(this, evlogErrorDataKey, {
+        value: opts.data,
+        enumerable: false,
+        writable: false,
+        configurable: true,
+      })
+    }
+
     // Maintain proper stack trace in V8
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, EvlogError)
@@ -99,12 +111,20 @@ export class EvlogError extends Error {
     return this.message
   }
 
-  /** Structured data for serialization */
-  get data(): { code?: string, why?: string, fix?: string, link?: string } | undefined {
-    if (this.code || this.why || this.fix || this.link) {
-      return { code: this.code, why: this.why, fix: this.fix, link: this.link }
+  /**
+   * Structured data for serialization: the guidance fields, merged over the
+   * payload passed as `createError({ data })`.
+   */
+  get data(): EvlogErrorData | undefined {
+    const extra = (this as EvlogError & { [evlogErrorDataKey]?: Record<string, unknown> })[evlogErrorDataKey]
+    if (!extra && !this.code && !this.why && !this.fix && !this.link) return undefined
+    return {
+      ...extra,
+      ...(this.code !== undefined && { code: this.code }),
+      ...(this.why !== undefined && { why: this.why }),
+      ...(this.fix !== undefined && { fix: this.fix }),
+      ...(this.link !== undefined && { link: this.link }),
     }
-    return undefined
   }
 
   override toString(): string {

--- a/packages/evlog/src/error.ts
+++ b/packages/evlog/src/error.ts
@@ -1,18 +1,12 @@
 import type { ErrorOptions, EvlogErrorData } from './types'
 import { colors, isServer } from './utils'
+import { evlogErrorBrand, isEvlogError as hasEvlogErrorBrand } from './shared/error-brand'
 
 /** Non-enumerable storage so `JSON.stringify(error)` never exposes internal context */
 const evlogErrorInternalKey = Symbol.for('evlog.error.internal')
 
 /** Non-enumerable storage; the payload reaches the wire through the `data` getter */
 const evlogErrorDataKey = Symbol.for('evlog.error.data')
-
-/**
- * Prototype brand read by {@link EvlogError.isEvlogError}. `instanceof` compares
- * class identity, which differs between duplicate installs of evlog — a
- * registry-shared symbol does not.
- */
-const evlogErrorBrand = Symbol.for('evlog.error.brand')
 
 /**
  * Structured error with context for better debugging
@@ -39,9 +33,7 @@ export class EvlogError extends Error {
    * silently reports `false`, downgrading a structured error to a bare 500.
    */
   static isEvlogError(error: unknown): error is EvlogError {
-    return typeof error === 'object'
-      && error !== null
-      && (error as Record<symbol, unknown>)[evlogErrorBrand] === true
+    return hasEvlogErrorBrand(error)
   }
 
   /** Stable, machine-readable identifier (e.g. `'PAYMENT_DECLINED'`). */

--- a/packages/evlog/src/index.ts
+++ b/packages/evlog/src/index.ts
@@ -84,6 +84,7 @@ export type {
   EnvironmentContext,
   ErrorCode,
   ErrorOptions,
+  EvlogErrorData,
   FieldContext,
   H3EventContext,
   IngestPayload,

--- a/packages/evlog/src/nitro-v3/errorHandler.ts
+++ b/packages/evlog/src/nitro-v3/errorHandler.ts
@@ -4,6 +4,7 @@ import {
   resolveEvlogError,
   extractErrorStatus,
   buildPlainNitroErrorBody,
+  isSensitiveNitroError,
   serializeEvlogErrorResponse,
   shouldSerializeNitroErrorAsJson,
   shouldSuppressNitroDevOverlay,
@@ -37,6 +38,8 @@ function getNitroV3RequestHeader(
 export default defineErrorHandler(async (error, event, ctx: NitroErrorHandlerContext) => {
   const evlogError = resolveEvlogError(error)
   const requestUrl = parseURL(event.req.url)
+  // Read before `suppressNitroDevOverlay` clears the flags it relies on.
+  const sensitive = isSensitiveNitroError(error)
 
   if (!shouldSerializeNitroErrorAsJson({
     pathname: requestUrl.pathname,
@@ -62,7 +65,7 @@ export default defineErrorHandler(async (error, event, ctx: NitroErrorHandlerCon
 
   const body = evlogError
     ? serializeEvlogErrorResponse(evlogError, url)
-    : buildPlainNitroErrorBody(error, url, isDev)
+    : buildPlainNitroErrorBody(error, url, { isDev, sensitive })
   const status = extractErrorStatus(evlogError ?? error)
 
   return new Response(JSON.stringify(body), {

--- a/packages/evlog/src/nitro.ts
+++ b/packages/evlog/src/nitro.ts
@@ -231,22 +231,63 @@ export function suppressNitroDevOverlay(error: Error): void {
 }
 
 /**
+ * Whether an error's own message and `data` are unsafe to return to the client.
+ *
+ * Mirrors Nitro: an error the developer shaped into an HTTP response is theirs
+ * to expose, an error that merely escaped a handler is not. h3 flags the latter
+ * as `unhandled`/`fatal`; errors carrying no status at all are treated the same
+ * way, since Nitro v3 derives `unhandled` from the error not being an HTTPError.
+ *
+ * @internal
+ */
+export function isSensitiveNitroError(error: Error): boolean {
+  const err = error as Error & {
+    unhandled?: boolean
+    fatal?: boolean
+    status?: unknown
+    statusCode?: unknown
+  }
+  if (err.unhandled || err.fatal) return true
+  return err.status === undefined && err.statusCode === undefined
+}
+
+/** @internal */
+export interface PlainNitroErrorBodyOptions {
+  /** Nitro's dev handler never sanitizes — it returns the message and `data` as thrown. */
+  isDev?: boolean
+  /**
+   * Whether to withhold the error's message and `data`. Defaults to
+   * {@link isSensitiveNitroError}; pass it explicitly when the flags it reads
+   * have already been cleared (see `suppressNitroDevOverlay`).
+   */
+  sensitive?: boolean
+}
+
+/**
  * Build Nitro-compatible JSON for non-EvlogError throws.
- * Sanitizes 5xx messages in production.
+ *
+ * Preserves `data` from `createError({ data })` the way Nitro's own handler
+ * does, and withholds the message and `data` of sensitive errors in production.
  */
 export function buildPlainNitroErrorBody(
   error: Error,
   url: string,
-  isDev = process.env.NODE_ENV === 'development',
+  options: PlainNitroErrorBodyOptions = {},
 ): Record<string, unknown> {
+  const {
+    isDev = process.env.NODE_ENV === 'development',
+    sensitive = isSensitiveNitroError(error),
+  } = options
+  const hide = sensitive && !isDev
+
   const status = extractErrorStatus(error)
   const shortStatus = (error as { statusText?: string }).statusText
     ?? (error as { statusMessage?: string }).statusMessage
   const rawMessage = error.message || shortStatus || 'Internal Server Error'
-  const sanitize = (text: string) =>
-    isDev ? text : (status >= 500 ? 'Internal Server Error' : text)
+  const sanitize = (text: string) => hide ? 'Internal Server Error' : text
   const message = sanitize(rawMessage)
   const statusMessage = sanitize(shortStatus ?? rawMessage)
+  const { data } = error as { data?: unknown }
 
   return {
     url,
@@ -256,6 +297,7 @@ export function buildPlainNitroErrorBody(
     statusMessage,
     message,
     error: true,
+    ...(!hide && data !== undefined && { data }),
   }
 }
 

--- a/packages/evlog/src/nitro/errorHandler.ts
+++ b/packages/evlog/src/nitro/errorHandler.ts
@@ -7,6 +7,7 @@ import {
   resolveEvlogError,
   extractErrorStatus,
   buildPlainNitroErrorBody,
+  isSensitiveNitroError,
   serializeEvlogErrorResponse,
   markH3ErrorHandled,
   shouldSerializeNitroErrorAsJson,
@@ -33,12 +34,15 @@ function endNodeResponse(event: H3Event, body: string): void {
  * This ensures that 'data' (containing 'why', 'fix', 'link') is preserved
  * in the JSON response regardless of the underlying HTTP framework.
  *
- * For non-EvlogError, it preserves Nitro's default response shape while
- * sanitizing internal error details in production for 5xx errors.
+ * For non-EvlogError, it preserves Nitro's default response shape — `data`
+ * from `createError({ data })` included — while withholding the details of
+ * unhandled errors in production.
  */
 export default defineNitroErrorHandler(async (error, event, ctx) => {
   const evlogError = resolveEvlogError(error)
   const requestUrl = getRequestURL(event, { xForwardedHost: true })
+  // Read before `suppressNitroDevOverlay` clears the flags it relies on.
+  const sensitive = isSensitiveNitroError(error)
 
   if (!shouldSerializeNitroErrorAsJson({
     pathname: requestUrl.pathname,
@@ -64,7 +68,7 @@ export default defineNitroErrorHandler(async (error, event, ctx) => {
   const url = requestUrl.pathname
 
   if (!evlogError) {
-    const body = buildPlainNitroErrorBody(error, url, isDev)
+    const body = buildPlainNitroErrorBody(error, url, { isDev, sensitive })
     setResponseStatus(event, body.status as number)
     setResponseHeader(event, 'Content-Type', 'application/json')
     return endNodeResponse(event, JSON.stringify(body))

--- a/packages/evlog/src/orpc/index.ts
+++ b/packages/evlog/src/orpc/index.ts
@@ -202,10 +202,8 @@ export function evlog<TContext extends Partial<EvlogOrpcContext> & Context = Evl
 
 function toOrpcError(error: EvlogError): ORPCError<string, Record<string, unknown>> {
   const parsed = parseError(error)
-  const data: Record<string, unknown> = {}
-  if (parsed.why !== undefined) data.why = parsed.why
-  if (parsed.fix !== undefined) data.fix = parsed.fix
-  if (parsed.link !== undefined) data.link = parsed.link
+  // `code` travels as the ORPC error code, the rest of the payload as its data.
+  const { code: _code, ...data } = parsed.data ?? {}
   return new ORPCError(parsed.code ?? 'EVLOG_ERROR', {
     status: parsed.status,
     message: parsed.message,

--- a/packages/evlog/src/runtime/utils/parseError.ts
+++ b/packages/evlog/src/runtime/utils/parseError.ts
@@ -1,6 +1,7 @@
 import type { FetchError } from 'ofetch'
 import type { ParsedError } from '../../types'
 import { extractErrorStatus } from '../../shared/errors'
+import { EvlogError } from '../../error'
 
 export type { ParsedError }
 
@@ -18,7 +19,11 @@ function pickRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined
 }
 
-/** An HTTP error body nests the payload under `data`; an error object is the payload. */
+/**
+ * Whether `data` is an HTTP error body rather than the payload itself. A body
+ * nests the payload under its own `data`; an EvlogError never does, so it is
+ * matched first and a payload keyed `statusCode` is not read as an envelope.
+ */
 function isErrorEnvelope(value: Record<string, unknown> | undefined): boolean {
   if (!value) return false
   return 'statusCode' in value || 'statusMessage' in value || 'statusText' in value || value.error === true
@@ -41,7 +46,9 @@ export function parseError(error: unknown): ParsedError {
       why: evlogData?.why,
       fix: evlogData?.fix,
       link: evlogData?.link,
-      data: isErrorEnvelope(pickRecord(data)) ? pickRecord(data?.data) : pickRecord(data),
+      data: !EvlogError.isEvlogError(error) && isErrorEnvelope(pickRecord(data))
+        ? pickRecord(data?.data)
+        : pickRecord(data),
       raw: error,
     }
   }

--- a/packages/evlog/src/runtime/utils/parseError.ts
+++ b/packages/evlog/src/runtime/utils/parseError.ts
@@ -19,10 +19,18 @@ function pickRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined
 }
 
-/** Whether `value` is a response body, which nests the payload under its own `data`. */
-function isErrorEnvelope(value: Record<string, unknown> | undefined): boolean {
-  if (!value) return false
-  return 'statusCode' in value || 'statusMessage' in value || 'statusText' in value || value.error === true
+/** What a serialized error says about itself. Never part of the client payload. */
+const responseMetadataKeys = new Set(['name', 'url', 'message', 'status', 'statusCode', 'statusText', 'statusMessage', 'error', 'cause', 'stack', 'data'])
+
+/**
+ * The payload of a body that carries no nested `data`: its own fields, minus the
+ * metadata every serializer wraps them in. Subtracting beats guessing whether a
+ * body is an envelope, which misreads a payload keyed `statusCode`.
+ */
+function payloadFromBody(body: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!body) return undefined
+  const entries = Object.entries(body).filter(([key]) => !responseMetadataKeys.has(key))
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined
 }
 
 function pickString(value: Record<string, unknown> | undefined, key: string): string | undefined {
@@ -50,6 +58,27 @@ function parseEvlogError(error: { message: string, data?: unknown }): ParsedErro
   }
 }
 
+/**
+ * Read any error into the flat shape a UI branches on: `message`, `status`,
+ * `code`, the `why` / `fix` / `link` guidance, and the client `data` payload.
+ *
+ * Accepts what each layer actually hands you: an {@link EvlogError} thrown
+ * server-side, an ofetch `FetchError` whose `data` is the parsed response body,
+ * that body on its own, an h3 error holding its payload on `data`, or any other
+ * `Error`. `raw` always carries the input back for debugging.
+ *
+ * `data` is the payload the server chose to expose, from `createError({ data })`
+ * merged with the guidance fields. It is read from the body's nested `data` when
+ * there is one, otherwise from the body's own fields with the response metadata
+ * (`status`, `message`, `url`, …) removed, so it never echoes the envelope. It is
+ * `undefined` when the error carries no payload. `internal` never appears here.
+ *
+ * @example
+ * ```ts
+ * const { message, why, fix, data } = parseError(error)
+ * if (typeof data?.retryAfter === 'number') scheduleRetry(data.retryAfter)
+ * ```
+ */
 export function parseError(error: unknown): ParsedError {
   if (isEvlogError(error)) {
     return parseEvlogError(error as { message: string, data?: unknown })
@@ -59,9 +88,8 @@ export function parseError(error: unknown): ParsedError {
     const { data, message: fetchMessage, statusCode: fetchStatusCode, status: fetchStatus } = error as FetchError & { status?: number }
 
     // A response body nests the payload under its own `data`. A flat body, or an
-    // h3 error holding the payload directly, is the payload.
-    const body = pickRecord(data)
-    const payload = pickRecord(data?.data) ?? (isErrorEnvelope(body) ? undefined : body)
+    // h3 error holding the payload directly, carries it among its own fields.
+    const payload = pickRecord(data?.data) ?? payloadFromBody(pickRecord(data))
 
     return {
       // Prefer statusText, then statusMessage (or message) for the error message

--- a/packages/evlog/src/runtime/utils/parseError.ts
+++ b/packages/evlog/src/runtime/utils/parseError.ts
@@ -19,22 +19,49 @@ function pickRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined
 }
 
-/**
- * Whether `data` is an HTTP error body rather than the payload itself. A body
- * nests the payload under its own `data`; an EvlogError never does, so it is
- * matched first and a payload keyed `statusCode` is not read as an envelope.
- */
+/** Whether `value` is a response body, which nests the payload under its own `data`. */
 function isErrorEnvelope(value: Record<string, unknown> | undefined): boolean {
   if (!value) return false
   return 'statusCode' in value || 'statusMessage' in value || 'statusText' in value || value.error === true
 }
 
+function pickString(value: Record<string, unknown> | undefined, key: string): string | undefined {
+  const found = value?.[key]
+  return typeof found === 'string' ? found : undefined
+}
+
+/**
+ * An EvlogError holds the payload on `data` itself and its own message and
+ * status on the error. Reading it through the envelope path below would let a
+ * payload keyed `statusCode` or `statusMessage` pass itself off as the response
+ * metadata.
+ */
+function parseEvlogError(error: { message: string, data?: unknown }): ParsedError {
+  const data = pickRecord(error.data)
+  return {
+    message: error.message,
+    status: extractErrorStatus(error),
+    code: pickCode(data) ?? pickCode(error),
+    why: pickString(data, 'why'),
+    fix: pickString(data, 'fix'),
+    link: pickString(data, 'link'),
+    data,
+    raw: error,
+  }
+}
+
 export function parseError(error: unknown): ParsedError {
+  if (isEvlogError(error)) {
+    return parseEvlogError(error as { message: string, data?: unknown })
+  }
+
   if (error && typeof error === 'object' && 'data' in error) {
     const { data, message: fetchMessage, statusCode: fetchStatusCode, status: fetchStatus } = error as FetchError & { status?: number }
 
-    // Support both nested data.data (fetch response) and direct data (EvlogError)
-    const evlogData = (data?.data ?? data) as { code?: string, why?: string, fix?: string, link?: string } | undefined
+    // A response body nests the payload under its own `data`. A flat body, or an
+    // h3 error holding the payload directly, is the payload.
+    const body = pickRecord(data)
+    const payload = pickRecord(data?.data) ?? (isErrorEnvelope(body) ? undefined : body)
 
     return {
       // Prefer statusText, then statusMessage (or message) for the error message
@@ -42,13 +69,11 @@ export function parseError(error: unknown): ParsedError {
       // Prefer status, then statusCode for the status value
       status: data?.status || data?.statusCode || fetchStatus || fetchStatusCode || 500,
       // Prefer the structured `data.code`, then `data.code` directly, then a top-level `error.code`
-      code: pickCode(evlogData) ?? pickCode(data) ?? pickCode(error),
-      why: evlogData?.why,
-      fix: evlogData?.fix,
-      link: evlogData?.link,
-      data: !isEvlogError(error) && isErrorEnvelope(pickRecord(data))
-        ? pickRecord(data?.data)
-        : pickRecord(data),
+      code: pickCode(payload) ?? pickCode(data) ?? pickCode(error),
+      why: pickString(payload, 'why'),
+      fix: pickString(payload, 'fix'),
+      link: pickString(payload, 'link'),
+      data: payload,
       raw: error,
     }
   }

--- a/packages/evlog/src/runtime/utils/parseError.ts
+++ b/packages/evlog/src/runtime/utils/parseError.ts
@@ -12,6 +12,18 @@ function pickCode(value: unknown): string | undefined {
   return undefined
 }
 
+function pickRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+/** An HTTP error body nests the payload under `data`; an error object is the payload. */
+function isErrorEnvelope(value: Record<string, unknown> | undefined): boolean {
+  if (!value) return false
+  return 'statusCode' in value || 'statusMessage' in value || 'statusText' in value || value.error === true
+}
+
 export function parseError(error: unknown): ParsedError {
   if (error && typeof error === 'object' && 'data' in error) {
     const { data, message: fetchMessage, statusCode: fetchStatusCode, status: fetchStatus } = error as FetchError & { status?: number }
@@ -29,6 +41,7 @@ export function parseError(error: unknown): ParsedError {
       why: evlogData?.why,
       fix: evlogData?.fix,
       link: evlogData?.link,
+      data: isErrorEnvelope(pickRecord(data)) ? pickRecord(data?.data) : pickRecord(data),
       raw: error,
     }
   }

--- a/packages/evlog/src/runtime/utils/parseError.ts
+++ b/packages/evlog/src/runtime/utils/parseError.ts
@@ -1,7 +1,7 @@
 import type { FetchError } from 'ofetch'
 import type { ParsedError } from '../../types'
 import { extractErrorStatus } from '../../shared/errors'
-import { EvlogError } from '../../error'
+import { isEvlogError } from '../../shared/error-brand'
 
 export type { ParsedError }
 
@@ -46,7 +46,7 @@ export function parseError(error: unknown): ParsedError {
       why: evlogData?.why,
       fix: evlogData?.fix,
       link: evlogData?.link,
-      data: !EvlogError.isEvlogError(error) && isErrorEnvelope(pickRecord(data))
+      data: !isEvlogError(error) && isErrorEnvelope(pickRecord(data))
         ? pickRecord(data?.data)
         : pickRecord(data),
       raw: error,

--- a/packages/evlog/src/shared/error-brand.ts
+++ b/packages/evlog/src/shared/error-brand.ts
@@ -1,0 +1,21 @@
+/**
+ * Prototype brand read by {@link isEvlogError}. `instanceof` compares class
+ * identity, which differs between duplicate installs of evlog, a
+ * registry-shared symbol does not.
+ *
+ * @internal
+ */
+export const evlogErrorBrand = Symbol.for('evlog.error.brand')
+
+/**
+ * Whether `error` is an `EvlogError`, including one thrown by a different copy
+ * of evlog. Kept out of `error.ts` so browser-side callers such as `parseError`
+ * can ask the question without pulling the class into their bundle.
+ *
+ * @internal Use `EvlogError.isEvlogError` from application code.
+ */
+export function isEvlogError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && (error as Record<symbol, unknown>)[evlogErrorBrand] === true
+}

--- a/packages/evlog/src/sveltekit/index.ts
+++ b/packages/evlog/src/sveltekit/index.ts
@@ -106,6 +106,7 @@ function evlogErrorFromContext(errorData: Record<string, unknown>): EvlogError {
     why: readString('why'),
     fix: readString('fix'),
     link: readString('link'),
+    data: nested,
   })
 }
 

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -976,10 +976,29 @@ export interface ErrorOptions {
   /** The original error that caused this */
   cause?: Error
   /**
+   * Extra payload returned to the client, merged into the response body's
+   * `data` object next to `code`, `why`, `fix` and `link` (those four win on
+   * a key collision). Mirrors h3's `createError({ data })`.
+   *
+   * For context that must never leave the server, use {@link ErrorOptions.internal}.
+   */
+  data?: Record<string, unknown>
+  /**
    * Backend-only diagnostic context (auditing, support, debugging).
    * Never included in HTTP responses or `EvlogError#toJSON`; included in wide events when the error is passed to `log.error()`.
    */
   internal?: Record<string, unknown>
+}
+
+/**
+ * Serialized `data` payload of an {@link import('./error').EvlogError} — the
+ * structured guidance fields plus anything passed as `createError({ data })`.
+ */
+export type EvlogErrorData = Record<string, unknown> & {
+  code?: string
+  why?: string
+  fix?: string
+  link?: string
 }
 
 /**
@@ -1056,5 +1075,10 @@ export interface ParsedError {
   why?: string
   fix?: string
   link?: string
+  /**
+   * The response body's `data` payload — the guidance fields plus anything the
+   * server passed as `createError({ data })`.
+   */
+  data?: Record<string, unknown>
   raw: unknown
 }

--- a/packages/evlog/test/core/error.test.ts
+++ b/packages/evlog/test/core/error.test.ts
@@ -227,6 +227,46 @@ describe('EvlogError', () => {
     })
   })
 
+  describe('data (client payload)', () => {
+    it('merges the payload into the data getter', () => {
+      const error = createError({
+        message: 'Payment failed',
+        status: 402,
+        why: 'Card declined',
+        data: { orderId: 'ord_1', retryable: true },
+      })
+
+      expect(error.data).toEqual({ orderId: 'ord_1', retryable: true, why: 'Card declined' })
+    })
+
+    it('returns the payload when no guidance field is set', () => {
+      expect(createError({ message: 'x', data: { key: 'value' } }).data).toEqual({ key: 'value' })
+    })
+
+    it('lets the guidance fields win on a key collision', () => {
+      const error = createError({
+        message: 'x',
+        code: 'PAYMENT_DECLINED',
+        data: { code: 'from-payload' },
+      })
+
+      expect(error.data?.code).toBe('PAYMENT_DECLINED')
+    })
+
+    it('serializes the payload to the client', () => {
+      const error = createError({ message: 'x', status: 402, data: { orderId: 'ord_1' } })
+
+      expect(error.toJSON().data).toEqual({ orderId: 'ord_1' })
+      expect(serializeEvlogErrorResponse(error, '/api/x').data).toEqual({ orderId: 'ord_1' })
+    })
+
+    it('does not duplicate the payload in JSON.stringify(error)', () => {
+      const error = createError({ message: 'x', data: { orderId: 'ord_1' } })
+
+      expect(JSON.parse(JSON.stringify(error)).data).toEqual({ orderId: 'ord_1' })
+    })
+  })
+
   describe('internal (backend-only)', () => {
     it('exposes internal via getter when provided', () => {
       const error = createError({
@@ -258,7 +298,7 @@ describe('EvlogError', () => {
       })
       const body = serializeEvlogErrorResponse(error, '/api/x')
       expect(body.internal).toBeUndefined()
-      expect(body.data).toEqual({ code: undefined, why: 'Reason', fix: undefined, link: undefined })
+      expect(body.data).toEqual({ why: 'Reason' })
     })
   })
 })
@@ -456,6 +496,24 @@ describe('parseError', () => {
       const parsed = parseError(error)
 
       expect(parsed.status).toBe(500)
+    })
+  })
+
+  describe('data payload', () => {
+    it('reads the payload from an EvlogError', () => {
+      const error = createError({ message: 'x', why: 'Card declined', data: { orderId: 'ord_1' } })
+
+      expect(parseError(error).data).toEqual({ orderId: 'ord_1', why: 'Card declined' })
+    })
+
+    it('reads the payload from a response body', () => {
+      const body = { statusCode: 402, message: 'Payment failed', data: { orderId: 'ord_1' } }
+
+      expect(parseError({ data: body }).data).toEqual({ orderId: 'ord_1' })
+    })
+
+    it('leaves data undefined when the response body carries none', () => {
+      expect(parseError({ data: { statusCode: 500, message: 'Boom' } }).data).toBeUndefined()
     })
   })
 

--- a/packages/evlog/test/core/error.test.ts
+++ b/packages/evlog/test/core/error.test.ts
@@ -536,6 +536,29 @@ describe('parseError', () => {
       expect(parsed.data).toMatchObject({ statusCode: 'upstream-500', data: { value: 1 } })
     })
 
+    it('leaves data undefined for a serialized error that carries no payload', () => {
+      const body = JSON.parse(JSON.stringify(createError({ message: 'Boom', status: 500 })))
+
+      expect(parseError({ data: body }).data).toBeUndefined()
+    })
+
+    it('reads the nested payload of a serialized error', () => {
+      const body = JSON.parse(JSON.stringify(
+        createError({ message: 'Payment failed', status: 402, why: 'Card declined', data: { orderId: 'ord_1' } }),
+      ))
+
+      const parsed = parseError({ data: body })
+
+      expect(parsed.why).toBe('Card declined')
+      expect(parsed.data).toMatchObject({ orderId: 'ord_1' })
+    })
+
+    it('keeps response metadata out of a flat body payload', () => {
+      const parsed = parseError({ data: { message: 'Payment failed', status: 402, why: 'Card declined' } })
+
+      expect(parsed.data).toEqual({ why: 'Card declined' })
+    })
+
     it('reads the payload an h3 error holds directly', () => {
       const h3Error = { message: 'Boom', statusCode: 402, data: { orderId: 'ord_1', why: 'Card declined' } }
 

--- a/packages/evlog/test/core/error.test.ts
+++ b/packages/evlog/test/core/error.test.ts
@@ -515,6 +515,14 @@ describe('parseError', () => {
     it('leaves data undefined when the response body carries none', () => {
       expect(parseError({ data: { statusCode: 500, message: 'Boom' } }).data).toBeUndefined()
     })
+
+    it('reads a payload whose keys collide with the response body shape', () => {
+      const statusCode = createError({ message: 'x', data: { statusCode: 'upstream-500' } })
+      expect(parseError(statusCode).data).toEqual({ statusCode: 'upstream-500' })
+
+      const flag = createError({ message: 'x', data: { error: true, field: 'email' } })
+      expect(parseError(flag).data).toEqual({ error: true, field: 'email' })
+    })
   })
 
   describe('code extraction', () => {

--- a/packages/evlog/test/core/error.test.ts
+++ b/packages/evlog/test/core/error.test.ts
@@ -516,6 +516,45 @@ describe('parseError', () => {
       expect(parseError({ data: { statusCode: 500, message: 'Boom' } }).data).toBeUndefined()
     })
 
+    it('reads every field from the error when the payload mimics a response body', () => {
+      const error = createError({
+        message: 'Payment failed',
+        status: 402,
+        why: 'Card declined',
+        data: {
+          statusCode: 'upstream-500',
+          statusMessage: 'payload-message',
+          data: { value: 1 },
+        },
+      })
+
+      const parsed = parseError(error)
+
+      expect(parsed.message).toBe('Payment failed')
+      expect(parsed.status).toBe(402)
+      expect(parsed.why).toBe('Card declined')
+      expect(parsed.data).toMatchObject({ statusCode: 'upstream-500', data: { value: 1 } })
+    })
+
+    it('reads the payload an h3 error holds directly', () => {
+      const h3Error = { message: 'Boom', statusCode: 402, data: { orderId: 'ord_1', why: 'Card declined' } }
+
+      const parsed = parseError(h3Error)
+
+      expect(parsed.message).toBe('Boom')
+      expect(parsed.status).toBe(402)
+      expect(parsed.why).toBe('Card declined')
+      expect(parsed.data).toEqual({ orderId: 'ord_1', why: 'Card declined' })
+    })
+
+    it('reads a flat body that carries the guidance at the top level', () => {
+      const parsed = parseError({ data: { message: 'Payment failed', why: 'Card declined', orderId: 'ord_1' } })
+
+      expect(parsed.message).toBe('Payment failed')
+      expect(parsed.why).toBe('Card declined')
+      expect(parsed.data).toMatchObject({ orderId: 'ord_1' })
+    })
+
     it('reads a payload whose keys collide with the response body shape', () => {
       const statusCode = createError({ message: 'x', data: { statusCode: 'upstream-500' } })
       expect(parseError(statusCode).data).toEqual({ statusCode: 'upstream-500' })

--- a/packages/evlog/test/frameworks/hono.test.ts
+++ b/packages/evlog/test/frameworks/hono.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Hono } from 'hono'
 import { initLogger } from '../../src/logger'
+import { createError } from '../../src/error'
+import { parseError } from '../../src/runtime/utils/parseError'
 import { evlog, useLogger, type EvlogVariables } from '../../src/hono/index'
 import {
   assertDrainCalledWith,
@@ -96,6 +98,34 @@ describe('evlog/hono', () => {
     await waitForDrainCalls(drain)
 
     assertHttpEventEmitted(drain, { path: '/api/fail', status: 500 })
+  })
+
+  it('carries the createError data payload through onError', async () => {
+    const { drain } = createPipelineSpies()
+    const app = new Hono<EvlogVariables>()
+    app.use(evlog({ drain }))
+    app.get('/api/checkout', () => {
+      throw createError({
+        message: 'Payment failed',
+        status: 402,
+        why: 'Card declined by issuer',
+        data: { orderId: 'ord_1', retryable: true },
+      })
+    })
+    app.onError((error, c) => {
+      const parsed = parseError(error)
+      return c.json({ message: parsed.message, ...parsed.data }, 402)
+    })
+
+    const response = await app.request('/api/checkout')
+    await waitForDrainCalls(drain)
+
+    expect(await response.json()).toEqual({
+      message: 'Payment failed',
+      why: 'Card declined by issuer',
+      orderId: 'ord_1',
+      retryable: true,
+    })
   })
 
   it('logs error context set manually by route handler', async () => {

--- a/packages/evlog/test/frameworks/orpc.test.ts
+++ b/packages/evlog/test/frameworks/orpc.test.ts
@@ -77,6 +77,15 @@ function buildRouter(trace?: { sawLogger: boolean, fromUseLogger: boolean }) {
     payNoCode: base.handler(() => {
       throw createError({ message: 'Boom', status: 418, why: 'Just because' })
     }),
+    payWithData: base.handler(() => {
+      throw createError({
+        message: 'Card declined',
+        code: 'PAYMENT_DECLINED',
+        status: 402,
+        why: 'Adhoc card declined',
+        data: { orderId: 'ord_1', retryable: true },
+      })
+    }),
   }
 }
 
@@ -302,6 +311,18 @@ describe('evlog/orpc', () => {
       const event = findEventViaDrain(drain, e => e.path === '/rpc/payAdHoc')
       expect(event!.level).toBe('error')
       expect(event!.status).toBe(402)
+    })
+
+    it('forwards the createError() data payload without the code', async () => {
+      const { client } = buildClient()
+
+      const result = await client.payWithData({}).catch(err => err)
+      expect(result.code).toBe('PAYMENT_DECLINED')
+      expect(result.data).toEqual({
+        why: 'Adhoc card declined',
+        orderId: 'ord_1',
+        retryable: true,
+      })
     })
 
     it('falls back to EVLOG_ERROR code when createError() omits code', async () => {

--- a/packages/evlog/test/frameworks/sveltekit.test.ts
+++ b/packages/evlog/test/frameworks/sveltekit.test.ts
@@ -120,6 +120,7 @@ describe('evlog/sveltekit', () => {
         why: 'Card declined by issuer',
         fix: 'Try a different card',
         link: 'https://docs.example.com/payments',
+        data: { orderId: 'ord_1' },
       })
     })
 
@@ -133,6 +134,7 @@ describe('evlog/sveltekit', () => {
     expect(body.data.why).toBe('Card declined by issuer')
     expect(body.data.fix).toBe('Try a different card')
     expect(body.data.link).toBe('https://docs.example.com/payments')
+    expect(body.data.orderId).toBe('ord_1')
   })
 
   it('logs EvlogError before returning structured response', async () => {
@@ -174,6 +176,7 @@ describe('evlog/sveltekit', () => {
       status: 402,
       why: 'Card declined',
       fix: 'Try another card',
+      data: { orderId: 'ord_1' },
     })
 
     // Simulate SvelteKit's resolve: calls handleError, then returns 500
@@ -194,6 +197,7 @@ describe('evlog/sveltekit', () => {
     expect(body.status).toBe(402)
     expect(body.data.why).toBe('Card declined')
     expect(body.data.fix).toBe('Try another card')
+    expect(body.data.orderId).toBe('ord_1')
   })
 
   it('skips routes not matching include patterns', async () => {

--- a/packages/evlog/test/next/handler.test.ts
+++ b/packages/evlog/test/next/handler.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createWithEvlog } from '../../src/next/handler'
 import { evlogStorage } from '../../src/next/storage'
 import { initLogger } from '../../src/logger'
+import { createError } from '../../src/error'
 import { defined } from '../helpers/defined'
 import { createDeferredStream } from '../helpers/stream'
 
@@ -93,6 +94,28 @@ describe('withEvlog', () => {
     const parsed = JSON.parse(output)
     expect(parsed.user).toEqual({ id: '123', plan: 'enterprise' })
     expect(parsed.cart).toEqual({ items: 5 })
+  })
+
+  it('returns a structured JSON response for a thrown EvlogError', async () => {
+    const withEvlog = createWithEvlog({ pretty: false })
+
+    const handler = withEvlog((_: Request) => {
+      throw createError({
+        message: 'Payment failed',
+        status: 402,
+        why: 'Card declined by issuer',
+        data: { orderId: 'ord_1', retryable: true },
+      })
+    })
+
+    const response = await handler(new Request('http://localhost/api/checkout', { method: 'POST' }))
+
+    expect(response.status).toBe(402)
+    expect(await response.json()).toMatchObject({
+      message: 'Payment failed',
+      status: 402,
+      data: { why: 'Card declined by issuer', orderId: 'ord_1', retryable: true },
+    })
   })
 
   it('captures errors and re-throws them', async () => {

--- a/packages/evlog/test/nitro-v2/fixture/routes/throws-h3-data.ts
+++ b/packages/evlog/test/nitro-v2/fixture/routes/throws-h3-data.ts
@@ -1,0 +1,9 @@
+import { createError, defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => {
+  throw createError({
+    status: 500,
+    message: 'Payment provider rejected the charge',
+    data: { orderId: 'ord_1', retryable: true },
+  })
+})

--- a/packages/evlog/test/nitro-v2/nitro-v2.test.ts
+++ b/packages/evlog/test/nitro-v2/nitro-v2.test.ts
@@ -94,6 +94,19 @@ describe.sequential('Nitro v2 server with evlog error handler', () => {
     })
   }, 15_000)
 
+  it('preserves data and message from a deliberate h3 createError', async () => {
+    const { status, body } = await fetchJson('/throws-h3-data')
+
+    expect(status).toBe(500)
+    expect(body).toMatchObject({
+      statusCode: 500,
+      url: '/throws-h3-data',
+      error: true,
+      message: 'Payment provider rejected the charge',
+      data: { orderId: 'ord_1', retryable: true },
+    })
+  }, 15_000)
+
   it('flushes plain thrown errors with Nitro-compatible JSON', async () => {
     const { status, body } = await fetchJson('/throws-plain')
 
@@ -104,5 +117,6 @@ describe.sequential('Nitro v2 server with evlog error handler', () => {
       error: true,
       message: expect.any(String),
     })
+    expect(body).not.toHaveProperty('data')
   }, 15_000)
 })

--- a/packages/evlog/test/nitro-v3/errorHandler.test.ts
+++ b/packages/evlog/test/nitro-v3/errorHandler.test.ts
@@ -197,16 +197,49 @@ describe('nitro-v3 errorHandler', () => {
       expect(body.statusMessage).toBe('Internal Server Error')
     })
 
-    it('sanitizes 5xx error messages in production', async () => {
+    it('preserves data from createError, like Nitro does', async () => {
+      const error = Object.assign(new Error('Payment provider rejected the charge'), {
+        statusCode: 500,
+        data: { orderId: 'ord_1', retryable: true },
+      })
+
+      const body = await readJson(await invokeErrorHandler(error))
+      expect(body.data).toEqual({ orderId: 'ord_1', retryable: true })
+    })
+
+    it('sanitizes unhandled error messages in production', async () => {
       vi.stubEnv('NODE_ENV', 'production')
 
       const error = Object.assign(new Error('Database connection failed: password invalid'), {
         statusCode: 500,
+        unhandled: true,
+        data: { query: 'select * from users' },
       })
 
       const body = await readJson(await invokeErrorHandler(error))
       expect(body.message).toBe('Internal Server Error')
       expect(body.statusMessage).toBe('Internal Server Error')
+      expect(body.data).toBeUndefined()
+    })
+
+    it('sanitizes statusless error messages in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+
+      const body = await readJson(await invokeErrorHandler(new Error('Database connection failed: password invalid')))
+      expect(body.message).toBe('Internal Server Error')
+    })
+
+    it('preserves a deliberate 5xx message and data in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+
+      const error = Object.assign(new Error('Payment provider rejected the charge'), {
+        statusCode: 500,
+        data: { orderId: 'ord_1' },
+      })
+
+      const body = await readJson(await invokeErrorHandler(error))
+      expect(body.message).toBe('Payment provider rejected the charge')
+      expect(body.data).toEqual({ orderId: 'ord_1' })
     })
 
     it('preserves 4xx error messages in production', async () => {

--- a/packages/evlog/test/nitro-v3/fixture/routes/throws-h3-data.ts
+++ b/packages/evlog/test/nitro-v3/fixture/routes/throws-h3-data.ts
@@ -1,0 +1,9 @@
+import { HTTPError, defineHandler } from 'nitro/h3'
+
+export default defineHandler(() => {
+  throw new HTTPError({
+    status: 500,
+    message: 'Payment provider rejected the charge',
+    data: { orderId: 'ord_1', retryable: true },
+  })
+})

--- a/packages/evlog/test/nitro-v3/nitro-v3.test.ts
+++ b/packages/evlog/test/nitro-v3/nitro-v3.test.ts
@@ -313,4 +313,17 @@ describe.sequential('Nitro v3 Server with evlog', () => {
       consola.restoreAll()
     }
   })
+
+  it('preserves data and message from a deliberate HTTPError', async () => {
+    const res = await server.fetch(new Request(new URL('/throws-h3-data', server.url)))
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toMatchObject({
+      statusCode: 500,
+      url: '/throws-h3-data',
+      error: true,
+      message: 'Payment provider rejected the charge',
+      data: { orderId: 'ord_1', retryable: true },
+    })
+  })
 })

--- a/packages/evlog/test/nitro/errorHandler.test.ts
+++ b/packages/evlog/test/nitro/errorHandler.test.ts
@@ -231,11 +231,24 @@ describe('errorHandler', () => {
       expect(sentBody.statusMessage).toBe('Internal Server Error')
     })
 
-    it('sanitizes 5xx error messages in production', async () => {
+    it('preserves data from createError, like Nitro does', async () => {
+      const error = Object.assign(new Error('Payment provider rejected the charge'), {
+        statusCode: 500,
+        data: { orderId: 'ord_1', retryable: true },
+      })
+
+      await invokeErrorHandler(error)
+
+      expect(readResponseBody().data).toEqual({ orderId: 'ord_1', retryable: true })
+    })
+
+    it('sanitizes unhandled error messages in production', async () => {
       vi.stubEnv('NODE_ENV', 'production')
 
       const error = Object.assign(new Error('Database connection failed: password invalid'), {
         statusCode: 500,
+        unhandled: true,
+        data: { query: 'select * from users' },
       })
 
       await invokeErrorHandler(error)
@@ -243,6 +256,41 @@ describe('errorHandler', () => {
       const sentBody = readResponseBody()
       expect(sentBody.message).toBe('Internal Server Error')
       expect(sentBody.statusMessage).toBe('Internal Server Error')
+      expect(sentBody.data).toBeUndefined()
+    })
+
+    it('sanitizes statusless error messages in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+
+      await invokeErrorHandler(new Error('Database connection failed: password invalid'))
+
+      expect(readResponseBody().message).toBe('Internal Server Error')
+    })
+
+    it('preserves a deliberate 5xx message and data in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+
+      const error = Object.assign(new Error('Payment provider rejected the charge'), {
+        statusCode: 500,
+        data: { orderId: 'ord_1' },
+      })
+
+      await invokeErrorHandler(error)
+
+      const sentBody = readResponseBody()
+      expect(sentBody.message).toBe('Payment provider rejected the charge')
+      expect(sentBody.data).toEqual({ orderId: 'ord_1' })
+    })
+
+    it('keeps unhandled error details in development', async () => {
+      const error = Object.assign(new Error('Database connection failed: password invalid'), {
+        statusCode: 500,
+        unhandled: true,
+      })
+
+      await invokeErrorHandler(error)
+
+      expect(readResponseBody().message).toBe('Database connection failed: password invalid')
     })
 
     it('preserves 4xx error messages in production', async () => {

--- a/skills/review-logging-patterns/SKILL.md
+++ b/skills/review-logging-patterns/SKILL.md
@@ -125,7 +125,7 @@ export default defineNuxtConfig({
 })
 ```
 
-All evlog functions (`useLogger`, `createError`, `parseError`, `log`) are **auto-imported**, with no import statements needed.
+`useLogger`, `log`, and `parseError` are **auto-imported**. `createError` is not: a bare one resolves to h3's, which drops `why`, `fix`, and `link`. Import it from `evlog`.
 
 ```typescript
 // server/api/checkout.post.ts — no imports needed
@@ -1157,7 +1157,7 @@ Recommend these when the review surfaces the matching need. Each has full docs o
 ## Structured Errors
 
 ```typescript
-import { createError } from 'evlog'  // or auto-imported in Nuxt
+import { createError } from 'evlog'  // required in Nuxt too: a bare createError is h3's
 
 // Minimal
 throw createError({ message: 'Database connection failed', status: 500 })

--- a/skills/review-logging-patterns/references/structured-errors.md
+++ b/skills/review-logging-patterns/references/structured-errors.md
@@ -69,7 +69,7 @@ Caused by: StripeCardError: card_declined
 
 ### JSON Output (Production)
 
-`EvlogError.toJSON()`, which every framework serializer returns:
+`EvlogError.toJSON()`, returned as-is by the Next.js handler:
 
 ```json
 {
@@ -90,7 +90,7 @@ Caused by: StripeCardError: card_declined
 }
 ```
 
-`why`, `fix`, and `link` are nested under `data`, not at the top level, and neither `internal` nor `stack` is ever included.
+The Nitro, Nuxt, and SvelteKit handlers return a Nitro-shaped body instead, with `url`, `statusCode`, `statusText`, and `error: true` around the same `message`, `status`, and `data`. Every serializer agrees on the part clients read: `why`, `fix`, and `link` sit under `data`, not at the top level, and neither `internal` nor `stack` is ever included. On the client, `parseError()` flattens both shapes.
 
 ## Field Guidelines
 

--- a/skills/review-logging-patterns/references/structured-errors.md
+++ b/skills/review-logging-patterns/references/structured-errors.md
@@ -33,12 +33,22 @@ throw createError({
   fix: 'Try a different payment method',  // How to fix it
   link: 'https://docs.example.com/...',   // More information
   cause: originalError,                   // Original error
+  data: {                                 // Optional: extra payload for the client
+    orderId: 'ord_8x2k',
+    retryAfter: 30,
+  },
   internal: {                             // Optional: backend / logs only
     correlationId: 'pay_abc',
     processorCode: 'card_declined',
   },
 })
 ```
+
+### `data` (client payload)
+
+- Use `data` for values the client branches on, an order id, a retry deadline, a list of invalid fields. `why`, `fix`, and `link` stay for the strings a human reads.
+- The payload is merged into the response body's `data` object next to `code`, `why`, `fix`, and `link`, and those four win on a key collision. Read it client-side as `parseError(error).data`.
+- Same field name as h3's `createError({ data })`, and evlog's Nitro error handler forwards it for h3 errors too.
 
 ### `internal` (backend-only)
 
@@ -322,7 +332,7 @@ Structured errors integrate seamlessly with wide events:
 
 ```typescript
 // server/api/checkout.post.ts
-// Nuxt: useLogger and createError are auto-imported
+// Nuxt: useLogger is auto-imported, createError is not
 // Nitro v3: import { useLogger } from 'evlog/nitro/v3'
 // Nitro v2: import { useLogger } from 'evlog/nitro'
 import { createError } from 'evlog'

--- a/skills/review-logging-patterns/references/structured-errors.md
+++ b/skills/review-logging-patterns/references/structured-errors.md
@@ -69,20 +69,28 @@ Caused by: StripeCardError: card_declined
 
 ### JSON Output (Production)
 
+`EvlogError.toJSON()`, which every framework serializer returns:
+
 ```json
 {
   "name": "EvlogError",
   "message": "Payment failed",
-  "why": "Card declined by issuer",
-  "fix": "Try a different payment method",
-  "link": "https://docs.example.com/payments/declined",
+  "status": 402,
+  "data": {
+    "orderId": "ord_8x2k",
+    "retryAfter": 30,
+    "why": "Card declined by issuer",
+    "fix": "Try a different payment method",
+    "link": "https://docs.example.com/payments/declined"
+  },
   "cause": {
     "name": "StripeCardError",
     "message": "card_declined"
-  },
-  "stack": "..."
+  }
 }
 ```
+
+`why`, `fix`, and `link` are nested under `data`, not at the top level, and neither `internal` nor `stack` is ever included.
 
 ## Field Guidelines
 

--- a/skills/review-logging-patterns/references/wide-events.md
+++ b/skills/review-logging-patterns/references/wide-events.md
@@ -138,7 +138,7 @@ With the evlog module, use `useLogger(event)` - it's auto-created and auto-emitt
 
 ```typescript
 // server/api/checkout.post.ts
-// Nuxt: useLogger and createError are auto-imported
+// Nuxt: useLogger is auto-imported, createError is not
 // Nitro v3: import { useLogger } from 'evlog/nitro/v3'
 // Nitro v2: import { useLogger } from 'evlog/nitro'
 import { createError } from 'evlog'
@@ -232,7 +232,7 @@ export default defineEventHandler(async (event) => {
 
 ```typescript
 // server/api/checkout.post.ts
-// Nuxt: useLogger and createError are auto-imported
+// Nuxt: useLogger is auto-imported, createError is not
 // Nitro v3: import { useLogger } from 'evlog/nitro/v3'
 // Nitro v2: import { useLogger } from 'evlog/nitro'
 import { createError } from 'evlog'


### PR DESCRIPTION
### 🔗 Linked issue

Closes #464

### 📚 Description

Two changes to the `data` payload on errors.

**Bug.** `evlog/nuxt` and `evlog/nitro` prepend their own error handler, and for any non-`EvlogError` throw it rebuilt the JSON body without `error.data`. Nitro's own handler returns `data: error.data`, so adding the module silently dropped the payload of every `createError({ data })` from h3. Reported on X with a Nuxt reproduction.

The handler now follows Nitro's rule for what it withholds instead of its own:

| | before | after |
|---|---|---|
| `createError({ status: 500, message, data })` in production | message hidden, `data` dropped | both kept |
| `throw new Error('secret')` in production | hidden | hidden (`unhandled`) |
| any error in development | message kept | message and `data` kept |

Sensitivity is read before `suppressNitroDevOverlay` clears the `unhandled` / `fatal` flags it relies on.

**Feature.** `createError({ data })` accepts an arbitrary payload, merged into the response body's `data` object next to `code`, `why`, `fix`, and `link`, which win on a key collision. Same field name as h3 so a migration is a no-op. Read client-side with `parseError(err).data`. `internal` stays the field that never leaves the server.

Verified on every integration that serializes errors itself: Nitro v2 and v3 (real dev-server fixtures), Next.js, SvelteKit on both its paths, oRPC. For Hono, Express, Fastify, Elysia, NestJS, React Router and Workers the user writes the handler, so the contract is `parseError(err).data`, covered by a Hono test replaying the pattern from the docs.

**Docs.** In a Nuxt app `createError` resolves to h3's on the server and Nuxt's in the app, never to evlog's, and h3 drops any field it does not know. Six doc pages and the published `review-logging-patterns` skill claimed evlog auto-imported it, so following them silently lost `why`, `fix`, and `link`. Corrected to import it from `evlog`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional client-facing data payloads to structured errors.
  * Preserved payloads across supported integrations and exposed them through error parsing.
  * Deliberate HTTP errors retain their messages and data in production responses.

* **Bug Fixes**
  * Improved production sanitization for unhandled or statusless errors.
  * Preserved structured data from h3 errors in responses.

* **Documentation**
  * Clarified Nuxt auto-import behavior and explicit `createError` usage.
  * Documented payload merging, access, and guidance-field precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->