### PR TITLE
fix(hono): capture errors handled by app.onError

### DIFF
--- a/.changeset/hono-onerror-capture.md
+++ b/.changeset/hono-onerror-capture.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+`evlog/hono` records errors again in apps that register `app.onError`. Hono hands a thrown error to `onError` at the route's own dispatch level, so the middleware resumed as if the request had succeeded and the failure was emitted as an info event with no `error` field. The wide event now carries the error and the status the handler actually returned.

--- a/packages/evlog/src/hono/index.ts
+++ b/packages/evlog/src/hono/index.ts
@@ -98,13 +98,16 @@ const integration = defineFrameworkIntegration<Context>({
  */
 export function evlog(options: EvlogHonoOptions = {}): MiddlewareHandler {
   return async (c, next) => {
-    const { skipped, finish, finishResponse, runWith } = integration.start(c, options)
+    const { skipped, logger, finish, finishResponse, runWith } = integration.start(c, options)
     if (skipped) {
       await next()
       return
     }
     try {
       await runWith(next)
+      // Hono's compose hands a thrown error to `app.onError` at the route's own
+      // dispatch level, so `next()` returns normally and `c.error` is the only trace.
+      if (c.error) logger.error(c.error)
       if (shouldDeferEmitForResponse(c.res)) {
         // Assign directly — Hono's compose ignores middleware return values when
         // context.finalized is already true, so returning the wrapped response

--- a/packages/evlog/test/frameworks/hono.test.ts
+++ b/packages/evlog/test/frameworks/hono.test.ts
@@ -126,6 +126,33 @@ describe('evlog/hono', () => {
       orderId: 'ord_1',
       retryable: true,
     })
+
+    const event = defined(
+      findEventViaDrain(drain, e => e.path === '/api/checkout'),
+      'checkout error event',
+    )
+    expect(event.level).toBe('error')
+    expect(event.status).toBe(402)
+    expect(event.error).toMatchObject({
+      name: 'EvlogError',
+      message: 'Payment failed',
+      data: { why: 'Card declined by issuer', orderId: 'ord_1', retryable: true },
+    })
+  })
+
+  it('records the response status onError returned, not the status of the error', async () => {
+    const { drain } = createPipelineSpies()
+    const app = new Hono<EvlogVariables>()
+    app.use(evlog({ drain }))
+    app.get('/api/fail', () => {
+      throw createError({ message: 'Payment failed', status: 402 })
+    })
+    app.onError((_error, c) => c.json({ error: 'handled' }, 500))
+
+    await app.request('/api/fail')
+    await waitForDrainCalls(drain)
+
+    assertHttpEventEmitted(drain, { path: '/api/fail', status: 500, level: 'error' })
   })
 
   it('logs error context set manually by route handler', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #643, now rebased on `main`.

### 📚 Description

`evlog/hono` lost every error in apps that register `app.onError`.

Hono's `compose` runs its `onError` catch at each dispatch level, so the route's own level handles the throw and turns it into a response. The middleware's `await next()` then returns as if the request had succeeded: the wide event came out at `info` level with no `error` field at all, no message, no code, no stack. `c.error` is the only remaining trace, and this reads it.

`finish({ status: c.res.status })` is kept deliberately. The `finish({ error })` path derives the status from the error, which is right when nothing has responded yet and wrong here: an `onError` that maps a 402 to a 500 sent the client a 500. A test locks that.

This also makes the terminal output shown on the Hono docs page true, since it is printed under exactly this setup.

Found while verifying #643 across the integrations. Elysia is unaffected, it registers its own global `.onError` hook.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
