### PR TITLE
docs: add sponsors section to readme

### DIFF
--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1507,6 +1507,18 @@ Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x
 3. **Request Scoping**: Accumulate context, emit once
 4. **Pretty for Dev, JSON for Prod**: Human-readable locally, machine-parseable in production
 
+<!-- automd:fetch url="gh:hugorcd/markdown/main/src/sponsors.md" -->
+
+## Sponsors
+
+<p align="center">
+  <a href="https://github.com/sponsors/HugoRCD">
+    <img src='https://cdn.jsdelivr.net/gh/hugorcd/static/sponsors.svg' alt="HugoRCD sponsors" />
+  </a>
+</p>
+
+<!-- /automd -->
+
 ## License
 
 [MIT](https://github.com/HugoRCD/evlog/blob/main/LICENSE)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

N/A — matches the Sponsors block used on HugoRCD/shelve and HugoRCD/nuxt-visitors.

### 📚 Description

Adds the automd-backed Sponsors section to `packages/evlog/README.md` (the root README symlink target), placed immediately before License. The rest of the README is unchanged.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26790c44-36ea-4806-b0a9-48c3794fda8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26790c44-36ea-4806-b0a9-48c3794fda8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Sponsors section to the project README.
  - Included sponsor images and a link to the project’s GitHub Sponsors page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->