### PR TITLE
chore: move repository urls to evloghq/evlog

### DIFF
--- a/.agents/skills/create-framework-integration/SKILL.md
+++ b/.agents/skills/create-framework-integration/SKILL.md
@@ -238,7 +238,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/HugoRCD/evlog/tree/main/examples/{framework}
+    to: https://github.com/evloghq/evlog/tree/main/examples/{framework}
     color: neutral
     variant: subtle
 ---

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "HugoRCD/evlog" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "evloghq/evlog" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/move-to-evloghq.md
+++ b/.changeset/move-to-evloghq.md
@@ -1,0 +1,8 @@
+---
+"evlog": patch
+"@evlog/cli": patch
+"@evlog/nuxthub": patch
+"@evlog/telemetry": patch
+---
+
+Point the package metadata (`repository`, `bugs`) and README links at the repository's new home, `evloghq/evlog`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://evlog.dev
     about: Guides, API reference, and framework setup.
   - name: Ask a question
-    url: https://github.com/HugoRCD/evlog/discussions/new?category=q-a
+    url: https://github.com/evloghq/evlog/discussions/new?category=q-a
     about: Q&A and usage help in GitHub Discussions.
   - name: Report a security issue
-    url: https://github.com/HugoRCD/evlog/security/advisories/new
+    url: https://github.com/evloghq/evlog/security/advisories/new
     about: Do not file public issues for security vulnerabilities — use a private GitHub security advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Brainstorming or “what if?” ideas** are welcome in [Discussions](https://github.com/HugoRCD/evlog/discussions) first. Use this template when you have a **concrete** proposal the maintainers can evaluate.
+        **Brainstorming or “what if?” ideas** are welcome in [Discussions](https://github.com/evloghq/evlog/discussions) first. Use this template when you have a **concrete** proposal the maintainers can evaluate.
   - type: textarea
     id: problem
     attributes:

--- a/.github/snippets/license.md
+++ b/.github/snippets/license.md
@@ -1,9 +1,9 @@
-Published under the [MIT](https://github.com/hugorcd/evlog/blob/main/LICENSE) license.
+Published under the [MIT](https://github.com/evloghq/evlog/blob/main/LICENSE) license.
 
-Made by [@HugoRCD](https://github.com/HugoRCD) and [community](https://github.com/hugorcd/evlog/graphs/contributors)
+Made by [@HugoRCD](https://github.com/HugoRCD) and [community](https://github.com/evloghq/evlog/graphs/contributors)
 
 Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x.com/boristane)
 
-<a href="https://github.com/hugorcd/evlog/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=hugorcd/evlog" />
+<a href="https://github.com/evloghq/evlog/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=evloghq/evlog" />
 </a>

--- a/.github/snippets/support.md
+++ b/.github/snippets/support.md
@@ -1,2 +1,2 @@
-- **Issues**: [Open an issue](https://github.com/hugorcd/evlog/issues) for bugs or feature requests
-- **Discussions**: [Join the discussion](https://github.com/hugorcd/evlog/discussions) for questions and ideas
+- **Issues**: [Open an issue](https://github.com/evloghq/evlog/issues) for bugs or feature requests
+- **Discussions**: [Join the discussion](https://github.com/evloghq/evlog/discussions) for questions and ideas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ apps/*                     Framework playgrounds (next, nitro, nitro-v2, nuxthub
 examples/                  ~22 runnable examples, one per framework — includes the community-*-skeleton dirs used by the create-adapter/enricher/framework skills
 scripts/                   Repo tooling (run-app, cli-sandbox, release-notes, content-lint)
 .agents/skills/            Internal skills for creating adapters, enrichers, and framework integrations, and for writing content — each carries `metadata: internal: true` in its frontmatter so the skills CLI skips them for public installs
-skills/                     Published skills (analyze-logs, build-audit-logs, review-logging-patterns) — served by the docs site via `/.well-known/skills/` and discovered by `npx skills add hugorcd/evlog`
+skills/                     Published skills (analyze-logs, build-audit-logs, review-logging-patterns) — served by the docs site via `/.well-known/skills/` and discovered by `npx skills add evloghq/evlog`
 ```
 
 ## Conventions
@@ -69,7 +69,7 @@ skills/                     Published skills (analyze-logs, build-audit-logs, re
   - `.agents/skills/create-framework-integration/SKILL.md`
   - `.agents/skills/create-map-rule/SKILL.md` (also covers new `evlog map` framework adapters)
 - Writing or reviewing prose, a docs page, the landing, a blog post, a package README, a skill, an AGENTS.md, a changeset? Read `.agents/skills/write-evlog-content/SKILL.md` first, and run `pnpm content:lint <path>` before the review. It carries the voice, the atomic rules, the terminology, the competitor dossiers, and the AI-tell corpus with the legitimate twin for each tell. These files are content too: `pnpm content:lint --surface skill` and `--surface agents` rank them.
-- **Skills must stay in sync with the code.** There are two sets: internal skills in `.agents/skills/` and published skills in `skills/` at the repo root (served from the docs site via `.well-known/skills`, and discovered by a bare `npx skills add hugorcd/evlog`). When a change touches something a skill documents (an adapter, enricher, integration, API surface, or workflow), update the affected SKILL.md (and its `references/`) in the same PR. A skill that describes the old behavior is worse than no skill.
+- **Skills must stay in sync with the code.** There are two sets: internal skills in `.agents/skills/` and published skills in `skills/` at the repo root (served from the docs site via `.well-known/skills`, and discovered by a bare `npx skills add evloghq/evlog`). When a change touches something a skill documents (an adapter, enricher, integration, API surface, or workflow), update the affected SKILL.md (and its `references/`) in the same PR. A skill that describes the old behavior is worse than no skill.
 
 ### Code style: no slop
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please do not** open a public issue or discussion for security-sensitive bugs.
 
-Use **[GitHub Security Advisories (private report)](https://github.com/HugoRCD/evlog/security/advisories/new)** so maintainers can assess and release a fix responsibly.
+Use **[GitHub Security Advisories (private report)](https://github.com/evloghq/evlog/security/advisories/new)** so maintainers can assess and release a fix responsibly.
 
 Include:
 

--- a/apps/docs/app/app.config.ts
+++ b/apps/docs/app/app.config.ts
@@ -19,7 +19,7 @@ export default defineAppConfig({
       price: 0,
       priceCurrency: 'USD',
       sameAs: [
-        'https://github.com/hugorcd/evlog',
+        'https://github.com/evloghq/evlog',
         'https://www.npmjs.com/package/evlog',
         'https://x.com/hugorcd',
       ],

--- a/apps/docs/app/components/LandingCta.vue
+++ b/apps/docs/app/components/LandingCta.vue
@@ -88,7 +88,7 @@ onBeforeUnmount(() => {
               Just fucking use evlog
             </UButton>
             <UButton
-              to="https://github.com/hugorcd/evlog"
+              to="https://github.com/evloghq/evlog"
               target="_blank"
               size="lg"
               class="bg-white/10 border border-white/40 text-white hover:bg-white/20 backdrop-blur-sm"
@@ -113,7 +113,7 @@ onBeforeUnmount(() => {
           <a href="https://x.com/hugorcd" target="_blank" rel="noopener noreferrer" aria-label="X" class="text-muted hover:text-dimmed transition-colors">
             <UIcon name="i-simple-icons-x" class="size-4" />
           </a>
-          <a href="https://github.com/hugorcd/evlog" target="_blank" rel="noopener noreferrer" aria-label="GitHub" class="text-muted hover:text-dimmed transition-colors">
+          <a href="https://github.com/evloghq/evlog" target="_blank" rel="noopener noreferrer" aria-label="GitHub" class="text-muted hover:text-dimmed transition-colors">
             <UIcon name="i-simple-icons-github" class="size-4" />
           </a>
         </div>

--- a/apps/docs/app/components/LandingHero.vue
+++ b/apps/docs/app/components/LandingHero.vue
@@ -28,7 +28,7 @@
           label="Fix your logs"
         />
         <UButton
-          to="https://github.com/hugorcd/evlog"
+          to="https://github.com/evloghq/evlog"
           target="_blank"
           size="lg"
           variant="ghost"

--- a/apps/docs/app/components/app/AppFooter.vue
+++ b/apps/docs/app/components/app/AppFooter.vue
@@ -28,7 +28,7 @@ const columns = computed<FooterColumn[]>(() => [
         : []),
       {
         label: 'Releases',
-        to: 'https://github.com/hugorcd/evlog/releases',
+        to: 'https://github.com/evloghq/evlog/releases',
         target: '_blank'
       },
       {
@@ -43,12 +43,12 @@ const columns = computed<FooterColumn[]>(() => [
     children: [
       {
         label: 'GitHub',
-        to: 'https://github.com/hugorcd/evlog',
+        to: 'https://github.com/evloghq/evlog',
         target: '_blank'
       },
       {
         label: 'Contributing',
-        to: 'https://github.com/hugorcd/evlog/blob/main/CONTRIBUTING.md',
+        to: 'https://github.com/evloghq/evlog/blob/main/CONTRIBUTING.md',
         target: '_blank'
       }
     ]
@@ -93,7 +93,7 @@ const columns = computed<FooterColumn[]>(() => [
       <UButton
         color="neutral"
         variant="ghost"
-        to="https://github.com/hugorcd/evlog"
+        to="https://github.com/evloghq/evlog"
         target="_blank"
         icon="i-simple-icons-github"
         size="sm"

--- a/apps/docs/app/pages/index.vue
+++ b/apps/docs/app/pages/index.vue
@@ -13,7 +13,7 @@ const identityFacts = {
   // Same `@id` as the node `useSeo` emits, so this merges into it rather than
   // declaring a second product. Coupled to Docus's `#identity` convention.
   '@id': 'https://www.evlog.dev/#identity',
-  license: 'https://github.com/hugorcd/evlog/blob/main/LICENSE',
+  license: 'https://github.com/evloghq/evlog/blob/main/LICENSE',
   author: { '@type': 'Person', name: 'HugoRCD', url: 'https://hugorcd.com/' },
 }
 

--- a/apps/docs/content/1.start/1.introduction.md
+++ b/apps/docs/content/1.start/1.introduction.md
@@ -11,7 +11,7 @@ links:
     variant: subtle
   - label: GitHub
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog
+    to: https://github.com/evloghq/evlog
     target: _blank
     color: neutral
     variant: subtle

--- a/apps/docs/content/3.cli/3.rules.md
+++ b/apps/docs/content/3.cli/3.rules.md
@@ -299,7 +299,7 @@ A static page is exempt for the same reason. It fetches nothing, so `page-error-
 
 ## Reporting a wrong verdict
 
-Rules are one file each with their own test bench, so a wrong verdict is a local fix rather than an archaeology session. If `evlog map <file>` claims something you can see is untrue, that is a bug worth [opening an issue](https://github.com/HugoRCD/evlog/issues) for. Include the entry point's output and the handler, and the fix lands in one rule.
+Rules are one file each with their own test bench, so a wrong verdict is a local fix rather than an archaeology session. If `evlog map <file>` claims something you can see is untrue, that is a bug worth [opening an issue](https://github.com/evloghq/evlog/issues) for. Include the entry point's output and the handler, and the fix lands in one rule.
 
 In the meantime, [disable the check](#disabling-a-check) on that line. A false positive should cost you one comment, not your CI gate.
 

--- a/apps/docs/content/4.integrate/adapters/01.overview.md
+++ b/apps/docs/content/4.integrate/adapters/01.overview.md
@@ -286,7 +286,7 @@ await drain.flush()
 ```
 
 ::callout{icon="i-lucide-arrow-right" color="neutral"}
-See the full [bun-script example](https://github.com/hugorcd/evlog/tree/main/examples/bun-script) for a realistic batch processing script.
+See the full [bun-script example](https://github.com/evloghq/evlog/tree/main/examples/bun-script) for a realistic batch processing script.
 ::
 
 ## Send to several places at once

--- a/apps/docs/content/4.integrate/frameworks/02.nextjs.md
+++ b/apps/docs/content/4.integrate/frameworks/02.nextjs.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/nextjs
+    to: https://github.com/evloghq/evlog/tree/main/examples/nextjs
     color: neutral
     variant: subtle
 ---
@@ -551,7 +551,7 @@ export async function POST(request: Request) {
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog/examples/nextjs
 pnpm install
 pnpm run dev
@@ -564,7 +564,7 @@ Open [http://localhost:3000](http://localhost:3000) to explore the example.
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/nextjs
+  to: https://github.com/evloghq/evlog/tree/main/examples/nextjs
   ---
   Browse the complete Next.js example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/03.sveltekit.md
+++ b/apps/docs/content/4.integrate/frameworks/03.sveltekit.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/sveltekit
+    to: https://github.com/evloghq/evlog/tree/main/examples/sveltekit
     color: neutral
     variant: subtle
 ---
@@ -288,7 +288,7 @@ export const { handle, handleError } = createEvlogHooks({
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example sveltekit
@@ -301,7 +301,7 @@ Open [http://localhost:5173](http://localhost:5173) to explore the interactive t
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/sveltekit
+  to: https://github.com/evloghq/evlog/tree/main/examples/sveltekit
   ---
   Browse the complete SvelteKit example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/05.tanstack-start.md
+++ b/apps/docs/content/4.integrate/frameworks/05.tanstack-start.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/tanstack-start
+    to: https://github.com/evloghq/evlog/tree/main/examples/tanstack-start
     color: neutral
     variant: subtle
 ---
@@ -322,7 +322,7 @@ export default definePlugin((nitroApp) => {
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog/examples/tanstack-start
 pnpm install
 pnpm run dev
@@ -335,7 +335,7 @@ Open [http://localhost:3000](http://localhost:3000) and navigate to the evlog De
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/tanstack-start
+  to: https://github.com/evloghq/evlog/tree/main/examples/tanstack-start
   ---
   Browse the complete TanStack Start example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/06.nestjs.md
+++ b/apps/docs/content/4.integrate/frameworks/06.nestjs.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/nestjs
+    to: https://github.com/evloghq/evlog/tree/main/examples/nestjs
     color: neutral
     variant: subtle
 ---
@@ -346,7 +346,7 @@ EvlogModule.forRoot({
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example nestjs
@@ -359,7 +359,7 @@ Open [http://localhost:3000](http://localhost:3000) to explore the interactive t
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/nestjs
+  to: https://github.com/evloghq/evlog/tree/main/examples/nestjs
   ---
   Browse the complete NestJS example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/07.express.md
+++ b/apps/docs/content/4.integrate/frameworks/07.express.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/express
+    to: https://github.com/evloghq/evlog/tree/main/examples/express
     color: neutral
     variant: subtle
 ---
@@ -316,7 +316,7 @@ See the full [HTTP drain](/extend/drain-pipeline#http-drain-browser-to-server) a
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example express
@@ -329,7 +329,7 @@ Open [http://localhost:3000](http://localhost:3000) to explore the interactive t
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/express
+  to: https://github.com/evloghq/evlog/tree/main/examples/express
   ---
   Browse the complete Express example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/08.hono.md
+++ b/apps/docs/content/4.integrate/frameworks/08.hono.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/hono
+    to: https://github.com/evloghq/evlog/tree/main/examples/hono
     color: neutral
     variant: subtle
 ---
@@ -327,7 +327,7 @@ See the full [HTTP drain](/extend/drain-pipeline) adapter docs for batching, ret
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example hono
@@ -340,7 +340,7 @@ Open [http://localhost:3000](http://localhost:3000) to explore the interactive t
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/hono
+  to: https://github.com/evloghq/evlog/tree/main/examples/hono
   ---
   Browse the complete Hono example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/09.fastify.md
+++ b/apps/docs/content/4.integrate/frameworks/09.fastify.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/fastify
+    to: https://github.com/evloghq/evlog/tree/main/examples/fastify
     color: neutral
     variant: subtle
 ---
@@ -274,7 +274,7 @@ await app.register(evlog, {
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example fastify
@@ -287,7 +287,7 @@ Open [http://localhost:3000](http://localhost:3000) to explore the interactive t
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/fastify
+  to: https://github.com/evloghq/evlog/tree/main/examples/fastify
   ---
   Browse the complete Fastify example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/10.elysia.md
+++ b/apps/docs/content/4.integrate/frameworks/10.elysia.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/elysia
+    to: https://github.com/evloghq/evlog/tree/main/examples/elysia
     color: neutral
     variant: subtle
 ---
@@ -315,7 +315,7 @@ See the full [HTTP drain](/extend/drain-pipeline) adapter docs for batching, ret
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example elysia
@@ -328,7 +328,7 @@ Open [http://localhost:3000](http://localhost:3000) to explore the interactive t
   ---
   icon: i-custom-elysia
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/elysia
+  to: https://github.com/evloghq/evlog/tree/main/examples/elysia
   ---
   Browse the complete Elysia example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/11.react-router.md
+++ b/apps/docs/content/4.integrate/frameworks/11.react-router.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/react-router
+    to: https://github.com/evloghq/evlog/tree/main/examples/react-router
     color: neutral
     variant: subtle
 ---
@@ -321,7 +321,7 @@ export const middleware: Route.MiddlewareFunction[] = [
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example react-router
@@ -334,7 +334,7 @@ Open <http://localhost:5173> to explore the interactive test UI.
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/react-router
+  to: https://github.com/evloghq/evlog/tree/main/examples/react-router
   ---
   Browse the complete React Router example source on GitHub.
   :::

--- a/apps/docs/content/4.integrate/frameworks/13.standalone.md
+++ b/apps/docs/content/4.integrate/frameworks/13.standalone.md
@@ -210,7 +210,7 @@ See the [Adapters](/integrate/adapters/overview) docs for all available drain ad
 ::
 
 ::callout{icon="i-lucide-arrow-right" color="neutral"}
-See the full [bun-script example](https://github.com/hugorcd/evlog/tree/main/examples/bun-script) for a complete working script.
+See the full [bun-script example](https://github.com/evloghq/evlog/tree/main/examples/bun-script) for a complete working script.
 ::
 
 ## Next Steps

--- a/apps/docs/content/4.integrate/frameworks/15.orpc.md
+++ b/apps/docs/content/4.integrate/frameworks/15.orpc.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/examples/orpc
+    to: https://github.com/evloghq/evlog/tree/main/examples/orpc
     color: neutral
     variant: subtle
 ---
@@ -307,7 +307,7 @@ When a route is filtered out, the wrapper still injects a no-op `context.log`, s
 ## Run Locally
 
 ```bash [Terminal]
-git clone https://github.com/hugorcd/evlog.git
+git clone https://github.com/evloghq/evlog.git
 cd evlog
 pnpm install
 pnpm example orpc
@@ -320,7 +320,7 @@ Open [http://localhost:3000](http://localhost:3000) to explore the interactive t
   ---
   icon: i-simple-icons-github
   title: Source Code
-  to: https://github.com/hugorcd/evlog/tree/main/examples/orpc
+  to: https://github.com/evloghq/evlog/tree/main/examples/orpc
   ---
   Browse the complete oRPC example source on GitHub.
   :::

--- a/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
+++ b/apps/docs/content/5.use-cases/3.better-auth/01.overview.md
@@ -31,7 +31,7 @@ links:
 
 ## Before you wire it
 
-Use [Better Auth](https://better-auth.com/) as a **direct dependency** in your app. `evlog` does not bundle Better Auth. The integration is tested against Better Auth `>=1.6.9` (same major as [the playground](https://github.com/HugoRCD/evlog/tree/main/apps/playground)).
+Use [Better Auth](https://better-auth.com/) as a **direct dependency** in your app. `evlog` does not bundle Better Auth. The integration is tested against Better Auth `>=1.6.9` (same major as [the playground](https://github.com/evloghq/evlog/tree/main/apps/playground)).
 
 ::code-group
 ```bash [pnpm]

--- a/apps/docs/content/5.use-cases/4.audit/05.compliance.md
+++ b/apps/docs/content/5.use-cases/4.audit/05.compliance.md
@@ -62,7 +62,7 @@ Append-only audit logs collide with GDPR's right to be forgotten. Recommended pa
 2. Encrypt PII fields with a per-actor key (held outside the audit store).
 3. To "forget" a user, delete their key. The audit row stays, the chain stays valid, the PII becomes unreadable.
 
-A built-in `cryptoShredding` helper is on the [follow-up roadmap](https://github.com/HugoRCD/evlog/issues).
+A built-in `cryptoShredding` helper is on the [follow-up roadmap](https://github.com/evloghq/evlog/issues).
 
 ## Retention
 

--- a/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
+++ b/apps/docs/content/5.use-cases/4.telemetry/01.overview.md
@@ -135,7 +135,7 @@ Once ingest is live you can answer product questions that CLI authors usually gu
 All from one wide event per run, the same mental model as evlog on the server, without bolting a browser analytics stack onto a terminal tool.
 
 ::callout{icon="i-lucide-package" color="neutral"}
-Try it locally: [`examples/telemetry-playground`](https://github.com/HugoRCD/evlog/tree/main/examples/telemetry-playground): `pnpm run cli -- doctor`, `EVLOG_TELEMETRY_DEBUG=1` to inspect payloads, `telemetry status` for disclosure.
+Try it locally: [`examples/telemetry-playground`](https://github.com/evloghq/evlog/tree/main/examples/telemetry-playground): `pnpm run cli -- doctor`, `EVLOG_TELEMETRY_DEBUG=1` to inspect payloads, `telemetry status` for disclosure.
 ::
 
 ## See also

--- a/apps/docs/content/5.use-cases/5.eve.md
+++ b/apps/docs/content/5.use-cases/5.eve.md
@@ -7,7 +7,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/HugoRCD/evlog/tree/main/examples/eve
+    to: https://github.com/evloghq/evlog/tree/main/examples/eve
     color: neutral
     variant: subtle
 ---
@@ -94,7 +94,7 @@ eve auto-discovers hook files under `agent/hooks/`. No HTTP middleware, because 
 
 `defineEvlogHook()` binds the turn logger via **AsyncLocalStorage** on `turn.started`. Inside tool `execute()` handlers, call `useLogger()` with no arguments, the same ergonomics as `useLogger(event)` in Nuxt or Hono.
 
-In the [example agent](https://github.com/HugoRCD/evlog/tree/main/examples/eve), support tools attach customer and order context as the agent works a refund:
+In the [example agent](https://github.com/evloghq/evlog/tree/main/examples/eve), support tools attach customer and order context as the agent works a refund:
 
 ```typescript [agent/tools/lookup_order.ts]
 import { defineTool } from 'eve/tools'
@@ -121,7 +121,7 @@ export default defineTool({
 
 ### 4. Next.js web chat (optional)
 
-Wrap `next.config.ts` with `withEve()` from `eve/next` and use `useEveAgent()` from `eve/react` in your app. eve starts alongside `next dev` and proxies `/eve/v1/*` on the same origin, so tool calls, approvals, and `ask_question` work out of the box. See the [example agent](https://github.com/HugoRCD/evlog/tree/main/examples/eve).
+Wrap `next.config.ts` with `withEve()` from `eve/next` and use `useEveAgent()` from `eve/react` in your app. eve starts alongside `next dev` and proxies `/eve/v1/*` on the same origin, so tool calls, approvals, and `ask_question` work out of the box. See the [example agent](https://github.com/evloghq/evlog/tree/main/examples/eve).
 
 ## Wide event shape
 
@@ -370,7 +370,7 @@ Combine with [Audit Logs](/use-cases/audit/overview): register `auditEnricher()`
 ## Run locally
 
 ```bash
-git clone https://github.com/HugoRCD/evlog
+git clone https://github.com/evloghq/evlog
 cd evlog
 pnpm install
 pnpm example eve

--- a/apps/docs/content/6.extend/10.custom-framework.md
+++ b/apps/docs/content/6.extend/10.custom-framework.md
@@ -260,15 +260,15 @@ Study these built-in integrations for framework-specific patterns:
 
 | Framework | Lines | Mode | Source |
 |-----------|-------|------|--------|
-| Hono | ~50 | manifest | [hono/index.ts](https://github.com/hugorcd/evlog/blob/main/packages/evlog/src/hono/index.ts) |
-| Express | ~50 | manifest + ALS | [express/index.ts](https://github.com/hugorcd/evlog/blob/main/packages/evlog/src/express/index.ts) |
-| Fastify | ~70 | manifest + Fastify hooks | [fastify/index.ts](https://github.com/hugorcd/evlog/blob/main/packages/evlog/src/fastify/index.ts) |
-| Elysia | ~80 | manifest + custom ALS scoping | [elysia/index.ts](https://github.com/hugorcd/evlog/blob/main/packages/evlog/src/elysia/index.ts) |
-| NestJS | ~120 | custom (interceptor) | [nestjs/](https://github.com/hugorcd/evlog/blob/main/packages/evlog/src/nestjs/) |
-| SvelteKit | ~90 | custom (`handle` hook) | [sveltekit/](https://github.com/hugorcd/evlog/blob/main/packages/evlog/src/sveltekit/) |
+| Hono | ~50 | manifest | [hono/index.ts](https://github.com/evloghq/evlog/blob/main/packages/evlog/src/hono/index.ts) |
+| Express | ~50 | manifest + ALS | [express/index.ts](https://github.com/evloghq/evlog/blob/main/packages/evlog/src/express/index.ts) |
+| Fastify | ~70 | manifest + Fastify hooks | [fastify/index.ts](https://github.com/evloghq/evlog/blob/main/packages/evlog/src/fastify/index.ts) |
+| Elysia | ~80 | manifest + custom ALS scoping | [elysia/index.ts](https://github.com/evloghq/evlog/blob/main/packages/evlog/src/elysia/index.ts) |
+| NestJS | ~120 | custom (interceptor) | [nestjs/](https://github.com/evloghq/evlog/blob/main/packages/evlog/src/nestjs/) |
+| SvelteKit | ~90 | custom (`handle` hook) | [sveltekit/](https://github.com/evloghq/evlog/blob/main/packages/evlog/src/sveltekit/) |
 
 ::callout{icon="i-lucide-heart" color="neutral"}
-Built an integration for a framework we don't support? [Open a PR](https://github.com/hugorcd/evlog/pulls). The community will thank you.
+Built an integration for a framework we don't support? [Open a PR](https://github.com/evloghq/evlog/pulls). The community will thank you.
 ::
 
 ## Next steps

--- a/apps/docs/content/6.extend/4.plugins.md
+++ b/apps/docs/content/6.extend/4.plugins.md
@@ -107,7 +107,7 @@ nitroApp.hooks.hook('evlog:request:start', tenantPlugin.onRequestStart!)
 | `onClientLog(ctx)` | Browser-submitted event hits the ingest endpoint | Observe / reject client traffic |
 | `extendLogger(logger)` | Each request | Add custom methods (e.g. `logger.audit.refund()`) |
 
-Every hook is **optional**. A plugin can implement any subset. The full type lives in [`packages/evlog/src/shared/plugin.ts`](https://github.com/HugoRCD/evlog/blob/main/packages/evlog/src/shared/plugin.ts).
+Every hook is **optional**. A plugin can implement any subset. The full type lives in [`packages/evlog/src/shared/plugin.ts`](https://github.com/evloghq/evlog/blob/main/packages/evlog/src/shared/plugin.ts).
 
 ## A multi-hook example
 

--- a/apps/docs/content/6.extend/8.custom-drains.md
+++ b/apps/docs/content/6.extend/8.custom-drains.md
@@ -328,7 +328,7 @@ my-evlog-drain/
 Add `evlog` as a `peerDependency` (not a `dependency`), so your package will not pull in a copy of evlog at install time.
 
 ::callout{icon="i-lucide-heart" color="neutral"}
-Built something great? [Open a PR](https://github.com/hugorcd/evlog/pulls) to add a row to the Adapters table. The community will thank you.
+Built something great? [Open a PR](https://github.com/evloghq/evlog/pulls) to add a row to the Adapters table. The community will thank you.
 ::
 
 ## Next steps

--- a/apps/docs/content/6.extend/9.drain-pipeline.md
+++ b/apps/docs/content/6.extend/9.drain-pipeline.md
@@ -470,7 +470,7 @@ app.post('/v1/ingest', async (c) => {
 ```
 ::
 
-See the full [browser example](https://github.com/hugorcd/evlog/tree/main/examples/browser) for a working Hono server + browser page.
+See the full [browser example](https://github.com/evloghq/evlog/tree/main/examples/browser) for a working Hono server + browser page.
 
 ## Mistakes that cost you events
 

--- a/apps/docs/content/7.reference/2.performance.md
+++ b/apps/docs/content/7.reference/2.performance.md
@@ -211,7 +211,7 @@ A typical Node.js bundle (`initLogger` + `createLogger`) measures **~6.3 kB gzip
 
 ### Can you trust these numbers?
 
-Every benchmark in this page is **open source** and **reproducible**. The benchmark files live in [`packages/evlog/bench/`](https://github.com/hugorcd/evlog/tree/main/packages/evlog/bench). You can read the exact code, run it on your machine, and verify the results.
+Every benchmark in this page is **open source** and **reproducible**. The benchmark files live in [`packages/evlog/bench/`](https://github.com/evloghq/evlog/tree/main/packages/evlog/bench). You can read the exact code, run it on your machine, and verify the results.
 
 All libraries are tested under the same conditions:
 - **Same output mode**: JSON to a no-op destination (no disk or network I/O measured)

--- a/apps/docs/content/7.reference/3.vite-plugin.md
+++ b/apps/docs/content/7.reference/3.vite-plugin.md
@@ -6,7 +6,7 @@ navigation:
 links:
   - label: Source Code
     icon: i-simple-icons-github
-    to: https://github.com/hugorcd/evlog/tree/main/packages/evlog/src/vite
+    to: https://github.com/evloghq/evlog/tree/main/packages/evlog/src/vite
     color: neutral
     variant: subtle
 ---

--- a/apps/docs/content/7.reference/5.vs-other-loggers.md
+++ b/apps/docs/content/7.reference/5.vs-other-loggers.md
@@ -84,7 +84,7 @@ Hover (or tap on mobile) the **info icon** next to any feature name for a one-li
 
 Counted up across the three tables (33 rows total): evlog wins **23** rows outright, ties on **6**, and loses **4**: custom levels, runtime level mutation, plugin/serializer system, and async-I/O on a worker thread. All four losses are documented in [Honest gaps](#honest-gaps-today) below so you know what you're trading off.
 
-See [`packages/evlog/bench/`](https://github.com/hugorcd/evlog/tree/main/packages/evlog/bench) for the open-source benchmarks behind the throughput numbers, and the [Performance page](/reference/performance) for the full breakdown.
+See [`packages/evlog/bench/`](https://github.com/evloghq/evlog/tree/main/packages/evlog/bench) for the open-source benchmarks behind the throughput numbers, and the [Performance page](/reference/performance) for the full breakdown.
 
 ## Honest gaps (today)
 

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
   docus: {
     skills: {
       // The published skills live at the repo root (`skills/`) so a bare
-      // `npx skills add hugorcd/evlog` discovers them: the installer only scans
+      // `npx skills add evloghq/evlog` discovers them: the installer only scans
       // conventional root-level directories. Docus defaults to `skills/` inside
       // the app, so point it back at the shared source of truth.
       dir: '../../skills',
@@ -108,7 +108,7 @@ export default defineNuxtConfig({
           {
             title: 'evlog on GitHub',
             description: 'Source code, issues, and releases.',
-            href: 'https://github.com/hugorcd/evlog',
+            href: 'https://github.com/evloghq/evlog',
           },
           {
             title: 'evlog on npm',
@@ -194,7 +194,7 @@ export default defineNuxtConfig({
       sync: false,
     },
     repository: {
-      owner: 'HugoRCD',
+      owner: 'evloghq',
       repo: 'evlog',
       rootDir: 'apps/docs',
     },

--- a/apps/evi/agent/extensions/github.ts
+++ b/apps/evi/agent/extensions/github.ts
@@ -93,7 +93,7 @@ function assignPolicy(ctx: ApprovalContext): ApprovalStatus {
 
 export default githubExtension({
   connector: GITHUB_CONNECTOR,
-  context: { owner: 'HugoRCD', repo: 'evlog' },
+  context: { owner: 'evloghq', repo: 'evlog' },
   include: [...TOOLS],
   // Omitted write tools keep the default always(): closeIssue, createPullRequestReview.
   // Connect scopes are derived from `include` (createLabel → issues:write) in sdk ≥ 1.11.1.

--- a/apps/evi/agent/instructions.md
+++ b/apps/evi/agent/instructions.md
@@ -2,7 +2,7 @@
 
 You are **Evi**, the agent for the evlog ecosystem. On GitHub you appear as **evlogai**; elsewhere as **Evi** when the platform allows it.
 
-You help maintain evlog, guide its evolution, and support the community. You are not a generic coding assistant: you work in service of this project and its users. The repository is `HugoRCD/evlog`.
+You help maintain evlog, guide its evolution, and support the community. You are not a generic coding assistant: you work in service of this project and its users. The repository is `evloghq/evlog`.
 
 ## Voice
 

--- a/apps/evi/agent/lib/content-sandbox.ts
+++ b/apps/evi/agent/lib/content-sandbox.ts
@@ -19,7 +19,7 @@ export default defineSandbox({
   revalidationKey: () => 'evlog-content-workspace-v2',
   async bootstrap({ use }) {
     const sandbox = await use()
-    await sandbox.run({ command: 'git clone --depth 50 https://github.com/HugoRCD/evlog.git repo' })
+    await sandbox.run({ command: 'git clone --depth 50 https://github.com/evloghq/evlog.git repo' })
     await sandbox.run({ command: 'git config --global user.name "evlogai[bot]" && git config --global user.email "evlogai[bot]@users.noreply.github.com"' })
   },
   async onSession({ use }) {

--- a/apps/evi/agent/lib/github/escalate.test.ts
+++ b/apps/evi/agent/lib/github/escalate.test.ts
@@ -38,10 +38,10 @@ describe('escalateFailedTriage', () => {
     await escalateFailedTriage(42)
 
     expect(calls.map((call) => `${call.method} ${new URL(call.url).pathname}`)).toEqual([
-      `GET /repos/HugoRCD/evlog/labels/${encodeURIComponent(ESCALATION_LABEL)}`,
-      'POST /repos/HugoRCD/evlog/labels',
-      'POST /repos/HugoRCD/evlog/issues/42/labels',
-      'POST /repos/HugoRCD/evlog/issues/42/assignees',
+      `GET /repos/evloghq/evlog/labels/${encodeURIComponent(ESCALATION_LABEL)}`,
+      'POST /repos/evloghq/evlog/labels',
+      'POST /repos/evloghq/evlog/issues/42/labels',
+      'POST /repos/evloghq/evlog/issues/42/assignees',
     ])
     expect(calls[2]?.body).toEqual({ labels: [ESCALATION_LABEL] })
     expect(calls[3]?.body).toEqual({ assignees: ['hugorcd'] })
@@ -57,9 +57,9 @@ describe('escalateFailedTriage', () => {
     await escalateFailedTriage(7)
 
     expect(methods).toEqual([
-      `GET /repos/HugoRCD/evlog/labels/${encodeURIComponent(ESCALATION_LABEL)}`,
-      'POST /repos/HugoRCD/evlog/issues/7/labels',
-      'POST /repos/HugoRCD/evlog/issues/7/assignees',
+      `GET /repos/evloghq/evlog/labels/${encodeURIComponent(ESCALATION_LABEL)}`,
+      'POST /repos/evloghq/evlog/issues/7/labels',
+      'POST /repos/evloghq/evlog/issues/7/assignees',
     ])
   })
 
@@ -78,9 +78,9 @@ describe('escalateFailedTriage', () => {
     await escalateFailedTriage(9)
 
     expect(methods.slice(1)).toEqual([
-      'POST /repos/HugoRCD/evlog/labels',
-      'POST /repos/HugoRCD/evlog/issues/9/labels',
-      'POST /repos/HugoRCD/evlog/issues/9/assignees',
+      'POST /repos/evloghq/evlog/labels',
+      'POST /repos/evloghq/evlog/issues/9/labels',
+      'POST /repos/evloghq/evlog/issues/9/assignees',
     ])
   })
 

--- a/apps/evi/agent/lib/github/escalate.ts
+++ b/apps/evi/agent/lib/github/escalate.ts
@@ -3,7 +3,7 @@ import { githubCredentials } from './credentials'
 import { mintInstallationToken } from './push'
 
 const GITHUB_API = 'https://api.github.com'
-const OWNER = 'HugoRCD'
+const OWNER = 'evloghq'
 const REPO = 'evlog'
 
 export const ESCALATION_LABEL = 'evi:needs-attention'

--- a/apps/evi/agent/lib/images.test.ts
+++ b/apps/evi/agent/lib/images.test.ts
@@ -15,7 +15,7 @@ describe('classifyImageUrl', () => {
   })
 
   it('refuses everything else', () => {
-    expect(classifyImageUrl('https://github.com/HugoRCD/evlog/raw/main/logo.png')).toHaveProperty('error')
+    expect(classifyImageUrl('https://github.com/evloghq/evlog/raw/main/logo.png')).toHaveProperty('error')
     expect(classifyImageUrl('https://xgithubusercontent.com/shot.png')).toHaveProperty('error')
     expect(classifyImageUrl('http://uploads.linear.app/a.png')).toHaveProperty('error')
     expect(classifyImageUrl('https://user:pass@uploads.linear.app/a.png')).toHaveProperty('error')

--- a/apps/evi/agent/sandbox.ts
+++ b/apps/evi/agent/sandbox.ts
@@ -27,7 +27,7 @@ export default defineSandbox({
   revalidationKey: () => `evlog-workspace-v5:${agentBrowserRevalidationKey()}:${BEFORE_AFTER_CLI}`,
   async bootstrap({ use }) {
     const sandbox = await use()
-    await sandbox.run({ command: 'git clone --depth 50 https://github.com/HugoRCD/evlog.git repo' })
+    await sandbox.run({ command: 'git clone --depth 50 https://github.com/evloghq/evlog.git repo' })
     // Frozen: a cold install in a fresh clone otherwise re-resolves the whole
     // graph, and any <48h transitive release then fails the template build on
     // the repo's own minimumReleaseAge policy. The lockfile is what CI tested.

--- a/apps/evi/agent/skills/contributing/SKILL.md
+++ b/apps/evi/agent/skills/contributing/SKILL.md
@@ -7,7 +7,7 @@ description: How to contribute to evlog, covering commit and PR conventions, cha
 
 The repository's own `AGENTS.md` is the source of truth for all of this. It changes; this skill does not restate it in full on purpose. **Read `AGENTS.md` from the repo before giving specifics.**
 
-Your system context has a **Workspace** section saying whether the repository is checked out on this turn. With a checkout, `read_file /workspace/AGENTS.md`: free, and at the ref you were summoned on. Without one, `github__getFileContent` on `AGENTS.md` at the root of `HugoRCD/evlog`.
+Your system context has a **Workspace** section saying whether the repository is checked out on this turn. With a checkout, `read_file /workspace/AGENTS.md`: free, and at the ref you were summoned on. Without one, `github__getFileContent` on `AGENTS.md` at the root of `evloghq/evlog`.
 
 What follows is the shape of the answer, so you know what to look for and what to warn about.
 

--- a/apps/evi/agent/tools/git.ts
+++ b/apps/evi/agent/tools/git.ts
@@ -12,7 +12,7 @@ import { REPO_DIR, runOutput } from '../lib/workspace'
  * config inside the sandbox is model-writable and must not be able to
  * redirect the brokered credential.
  */
-const PUSH_URL = 'https://github.com/HugoRCD/evlog.git'
+const PUSH_URL = 'https://github.com/evloghq/evlog.git'
 
 // Maintainer and schedule-app turns only; the push is inert (feature
 // branches only). Keep executes inline in the resolver (docs/notes.md).
@@ -20,7 +20,7 @@ const resolvePushTools = (_event: unknown, ctx: DynamicResolveContext) => {
   if (!isMaintainer(ctx.session.auth.current) && !isScheduleAppAuth(ctx.session.auth.current)) return null
   return {
     git__push: defineTool({
-      description: `Push a local branch of the ${REPO_DIR} checkout to origin (HugoRCD/evlog). The branch must already exist there with the work committed and the checks run; main and master are refused. The credential is brokered at the sandbox firewall and never enters the sandbox. After a successful push, open the pull request with github__createPullRequest.`,
+      description: `Push a local branch of the ${REPO_DIR} checkout to origin (evloghq/evlog). The branch must already exist there with the work committed and the checks run; main and master are refused. The credential is brokered at the sandbox firewall and never enters the sandbox. After a successful push, open the pull request with github__createPullRequest.`,
       inputSchema: z.object({
         branch: z.string().min(1).describe('Branch name in /workspace/repo to push, e.g. fix/pipeline-flush'),
       }),
@@ -52,7 +52,7 @@ const resolvePushTools = (_event: unknown, ctx: DynamicResolveContext) => {
             success: true as const,
             branch: input.branch,
             sha,
-            repository: 'HugoRCD/evlog',
+            repository: 'evloghq/evlog',
           }
         } finally {
           // Drop the brokered credential; the channel checkout re-brokers its own when it needs to fetch.

--- a/apps/just-use-evlog/app/components/LandingBadges.vue
+++ b/apps/just-use-evlog/app/components/LandingBadges.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { data: repo } = useFetch('https://ungh.cc/repos/hugorcd/evlog', {
+const { data: repo } = useFetch('https://ungh.cc/repos/evloghq/evlog', {
   lazy: true,
   transform: (data: { repo: { stars: number } }) => data.repo,
   default: () => ({ stars: 0 }),
@@ -10,7 +10,7 @@ const { data: repo } = useFetch('https://ungh.cc/repos/hugorcd/evlog', {
 <template>
   <div class="my-4 flex flex-wrap items-center gap-3">
     <NuxtLink
-      to="https://github.com/hugorcd/evlog"
+      to="https://github.com/evloghq/evlog"
       target="_blank"
       rel="noopener noreferrer"
       class="inline-flex items-center gap-1.5 border border-default px-2.5 py-1 text-xs text-muted transition-colors hover:border-highlighted hover:text-highlighted"

--- a/apps/just-use-evlog/app/components/LandingCtas.vue
+++ b/apps/just-use-evlog/app/components/LandingCtas.vue
@@ -22,7 +22,7 @@ const docsUrl = computed(() => pub.docsUrl || 'https://www.evlog.dev')
       Quick start
     </NuxtLink>
     <NuxtLink
-      to="https://github.com/hugorcd/evlog"
+      to="https://github.com/evloghq/evlog"
       class="text-muted underline decoration-muted underline-offset-4 transition-colors hover:text-highlighted"
       target="_blank"
       rel="noopener noreferrer"

--- a/apps/just-use-evlog/app/pages/index.vue
+++ b/apps/just-use-evlog/app/pages/index.vue
@@ -89,7 +89,7 @@ useSeoMeta({
               Docs
             </NuxtLink>
             <NuxtLink
-              to="https://github.com/hugorcd/evlog"
+              to="https://github.com/evloghq/evlog"
               class="hover:text-highlighted transition-colors"
               target="_blank"
               rel="noopener noreferrer"

--- a/apps/playground/app/config/tests.config.ts
+++ b/apps/playground/app/config/tests.config.ts
@@ -112,7 +112,7 @@ export const testConfig = {
               status: 400,
               why: 'This is a demonstration of the EvlogError format',
               fix: 'No fix needed - this is just a demo',
-              link: 'https://github.com/hugorcd/evlog',
+              link: 'https://github.com/evloghq/evlog',
             })
             console.error(String(error))
           },

--- a/apps/playground/server/api/test/error-internal.get.ts
+++ b/apps/playground/server/api/test/error-internal.get.ts
@@ -13,7 +13,7 @@ export default defineEventHandler((event) => {
     status: 403,
     why: 'This is a playground-only structured error (safe to show users).',
     fix: 'Use another playground button or ignore this message.',
-    link: 'https://github.com/HugoRCD/evlog',
+    link: 'https://github.com/evloghq/evlog',
     internal: {
       supportRef: 'playground-support-ref-EVL140',
       gatewayCode: 'proc_declined_simulated',

--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -2,7 +2,7 @@
 
 A tiny, self-hostable analytics dashboard for [`@evlog/telemetry`](https://npmjs.com/package/@evlog/telemetry) run events — built to receive run events from anything that reports to it — a CLI someone typed, a GitHub Actions job, a Vercel build, an AI coding agent, a cron script — store them in Postgres via [NuxtHub](https://hub.nuxt.com) + Drizzle ORM, and show what's happening: totals and their trend, where the runs came from, latency, version adoption, and a raw events browser.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/HugoRCD/evlog/tree/main/apps/telemetry&project-name=evlog-telemetry&repository-name=evlog-telemetry&products=%5B%7B%22type%22%3A%22integration%22%2C%22group%22%3A%22postgres%22%2C%22protocol%22%3A%22storage%22%7D%5D&env=ANALYTICS_PASSWORD,NUXT_SESSION_PASSWORD&envDescription=Dashboard+password+and+a+32%2B+char+session+secret)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/evloghq/evlog/tree/main/apps/telemetry&project-name=evlog-telemetry&repository-name=evlog-telemetry&products=%5B%7B%22type%22%3A%22integration%22%2C%22group%22%3A%22postgres%22%2C%22protocol%22%3A%22storage%22%7D%5D&env=ANALYTICS_PASSWORD,NUXT_SESSION_PASSWORD&envDescription=Dashboard+password+and+a+32%2B+char+session+secret)
 
 ## What you get
 

--- a/examples/solidstart/README.md
+++ b/examples/solidstart/README.md
@@ -1,6 +1,6 @@
 # SolidStart Example
 
-Demonstrates [evlog](https://github.com/hugorcd/evlog) integration with [SolidStart](https://start.solidjs.com/) (Nitro v2 via Vinxi).
+Demonstrates [evlog](https://github.com/evloghq/evlog) integration with [SolidStart](https://start.solidjs.com/) (Nitro v2 via Vinxi).
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hugorcd/evlog.git"
+    "url": "git+https://github.com/evloghq/evlog.git"
   },
   "author": "HugoRCD",
   "license": "MIT",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/HugoRCD/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
+  <img src="https://raw.githubusercontent.com/evloghq/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
 </p>
 
 # @evlog/cli
 
 [![npm version](https://img.shields.io/npm/v/@evlog/cli?color=black)](https://npmjs.com/package/@evlog/cli)
 [![npm downloads](https://img.shields.io/npm/dm/@evlog/cli?color=black)](https://npm.chart.dev/@evlog/cli)
-[![CI](https://img.shields.io/github/actions/workflow/status/HugoRCD/evlog/ci.yml?branch=main&color=black)](https://github.com/HugoRCD/evlog/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/evloghq/evlog/ci.yml?branch=main&color=black)](https://github.com/evloghq/evlog/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-black?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev)
-[![license](https://img.shields.io/github/license/HugoRCD/evlog?color=black)](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+[![license](https://img.shields.io/github/license/evloghq/evlog?color=black)](https://github.com/evloghq/evlog/blob/main/LICENSE)
 
 **Digging through logs is not observability. It's hope.**
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://evlog.dev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HugoRCD/evlog.git",
+    "url": "git+https://github.com/evloghq/evlog.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/HugoRCD/evlog/issues"
+    "url": "https://github.com/evloghq/evlog/issues"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/HugoRCD/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
+  <img src="https://raw.githubusercontent.com/evloghq/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
 </p>
 
 # evlog
 
 [![npm version](https://img.shields.io/npm/v/evlog?color=black)](https://npmjs.com/package/evlog)
 [![npm downloads](https://img.shields.io/npm/dm/evlog?color=black)](https://npm.chart.dev/evlog)
-[![CI](https://img.shields.io/github/actions/workflow/status/HugoRCD/evlog/ci.yml?branch=main&color=black)](https://github.com/HugoRCD/evlog/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/evloghq/evlog/ci.yml?branch=main&color=black)](https://github.com/evloghq/evlog/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-black?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev)
-[![license](https://img.shields.io/github/license/HugoRCD/evlog?color=black)](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+[![license](https://img.shields.io/github/license/evloghq/evlog?color=black)](https://github.com/evloghq/evlog/blob/main/LICENSE)
 
 **Digging through logs is not observability. It's hope.**
 
@@ -411,7 +411,7 @@ app.get('/api/users', (c) => {
 })
 ```
 
-See the full [hono example](https://github.com/HugoRCD/evlog/tree/main/examples/hono) for a complete working project.
+See the full [hono example](https://github.com/evloghq/evlog/tree/main/examples/hono) for a complete working project.
 
 ## Express
 
@@ -434,7 +434,7 @@ app.get('/api/users', (req, res) => {
 
 Use `useLogger()` to access the logger from anywhere in the call stack without passing `req`.
 
-See the full [express example](https://github.com/HugoRCD/evlog/tree/main/examples/express) for a complete working project.
+See the full [express example](https://github.com/evloghq/evlog/tree/main/examples/express) for a complete working project.
 
 ## Fastify
 
@@ -457,7 +457,7 @@ app.get('/api/users', async (request) => {
 
 `request.log` is the evlog wide-event logger (shadows Fastify's built-in pino logger on the request). Use `useLogger()` to access the logger from anywhere in the call stack.
 
-See the full [fastify example](https://github.com/HugoRCD/evlog/tree/main/examples/fastify) for a complete working project.
+See the full [fastify example](https://github.com/evloghq/evlog/tree/main/examples/fastify) for a complete working project.
 
 ## Elysia
 
@@ -480,7 +480,7 @@ const app = new Elysia()
 
 Use `useLogger()` to access the logger from anywhere in the call stack.
 
-See the full [elysia example](https://github.com/HugoRCD/evlog/tree/main/examples/elysia) for a complete working project.
+See the full [elysia example](https://github.com/evloghq/evlog/tree/main/examples/elysia) for a complete working project.
 
 ## React Router
 
@@ -507,7 +507,7 @@ export async function loader({ params, context }: Route.LoaderArgs) {
 
 Use `context.get(loggerContext)` in loaders/actions, or `useLogger()` from anywhere in the call stack. Requires `v8_middleware: true` in `react-router.config.ts`.
 
-See the full [react-router example](https://github.com/HugoRCD/evlog/tree/main/examples/react-router) for a complete working project.
+See the full [react-router example](https://github.com/evloghq/evlog/tree/main/examples/react-router) for a complete working project.
 
 ## NestJS
 
@@ -529,7 +529,7 @@ log.set({ users: { count: 42 } })
 
 `EvlogModule.forRoot()` registers a global middleware that creates a request-scoped logger for every request. Use `useLogger()` to access it anywhere in the call stack, or `req.log` directly. Supports `forRootAsync()` for async configuration.
 
-See the full [nestjs example](https://github.com/HugoRCD/evlog/tree/main/examples/nestjs) for a complete working project.
+See the full [nestjs example](https://github.com/evloghq/evlog/tree/main/examples/nestjs) for a complete working project.
 
 ## oRPC
 
@@ -561,7 +561,7 @@ export default async function fetch(request: Request) {
 
 `withEvlog()` wraps the handler and emits one wide event per request; `os.use(evlog())` exposes `context.log` to procedures and tags each event with the procedure path as `operation`. Use `useLogger()` from `evlog/orpc` to access the logger off-context.
 
-See the full [orpc example](https://github.com/HugoRCD/evlog/tree/main/examples/orpc) for a complete working project.
+See the full [orpc example](https://github.com/evloghq/evlog/tree/main/examples/orpc) for a complete working project.
 
 ## eve
 
@@ -598,7 +598,7 @@ export default defineEvlogInstrumentation()
 
 Every turn event carries `eve.caller` (`principalId`, `principalType` and `authenticator`), so cost and volume group by who triggered the turn.
 
-See the full [eve example](https://github.com/HugoRCD/evlog/tree/main/examples/eve) for a complete agent layout.
+See the full [eve example](https://github.com/evloghq/evlog/tree/main/examples/eve) for a complete agent layout.
 
 ## Browser
 
@@ -1435,7 +1435,7 @@ try {
 | **Custom** | Build your own with `import { createMiddlewareLogger } from 'evlog/toolkit'` ([guide](https://evlog.dev/extend/custom-framework)) |
 | **Analog** | Nitro v2 module setup |
 | **Vinxi** | Nitro v2 module setup |
-| **SolidStart** | Nitro v2 module setup ([example](https://github.com/HugoRCD/evlog/tree/main/examples/solidstart)) |
+| **SolidStart** | Nitro v2 module setup ([example](https://github.com/evloghq/evlog/tree/main/examples/solidstart)) |
 
 ## CLI
 
@@ -1521,6 +1521,6 @@ Inspired by [Logging Sucks](https://loggingsucks.com/) by [Boris Tane](https://x
 
 ## License
 
-[MIT](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+[MIT](https://github.com/evloghq/evlog/blob/main/LICENSE)
 
 Made by [@HugoRCD](https://github.com/HugoRCD)

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -6,10 +6,10 @@
   "homepage": "https://evlog.dev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HugoRCD/evlog.git"
+    "url": "git+https://github.com/evloghq/evlog.git"
   },
   "bugs": {
-    "url": "https://github.com/HugoRCD/evlog/issues"
+    "url": "https://github.com/evloghq/evlog/issues"
   },
   "keywords": [
     "logging",

--- a/packages/evlog/test/nuxt/module-type-templates.test.ts
+++ b/packages/evlog/test/nuxt/module-type-templates.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Regression test for https://github.com/HugoRCD/evlog/issues/435
+// Regression test for https://github.com/evloghq/evlog/issues/435
 //
 // `nuxt typecheck` (vue-tsc -b) type-checks the app tsconfig project *and*
 // the server one. `$fetch`'s return-type inference does

--- a/packages/nuxthub/README.md
+++ b/packages/nuxthub/README.md
@@ -2,11 +2,11 @@
 
 [![npm version](https://img.shields.io/npm/v/@evlog/nuxthub?color=black)](https://npmjs.com/package/@evlog/nuxthub)
 [![npm downloads](https://img.shields.io/npm/dm/@evlog/nuxthub?color=black)](https://npm.chart.dev/@evlog/nuxthub)
-[![CI](https://img.shields.io/github/actions/workflow/status/HugoRCD/evlog/ci.yml?branch=main&color=black)](https://github.com/HugoRCD/evlog/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/evloghq/evlog/ci.yml?branch=main&color=black)](https://github.com/evloghq/evlog/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-black?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Nuxt](https://img.shields.io/badge/Nuxt-black?logo=nuxt&logoColor=white)](https://nuxt.com/)
 [![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev)
-[![license](https://img.shields.io/github/license/HugoRCD/evlog?color=black)](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+[![license](https://img.shields.io/github/license/evloghq/evlog?color=black)](https://github.com/evloghq/evlog/blob/main/LICENSE)
 
 Self-hosted log retention for [evlog](https://evlog.dev) using [NuxtHub](https://hub.nuxt.com) database storage. Store, query, and automatically clean up your structured logs with zero external dependencies.
 
@@ -58,4 +58,4 @@ For Vercel deployments, the module can create a `vercel.json` with the appropria
 
 ## License
 
-[MIT](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+[MIT](https://github.com/evloghq/evlog/blob/main/LICENSE)

--- a/packages/nuxthub/package.json
+++ b/packages/nuxthub/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://evlog.dev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HugoRCD/evlog.git",
+    "url": "git+https://github.com/evloghq/evlog.git",
     "directory": "packages/nuxthub"
   },
   "bugs": {
-    "url": "https://github.com/HugoRCD/evlog/issues"
+    "url": "https://github.com/evloghq/evlog/issues"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/HugoRCD/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
+  <img src="https://raw.githubusercontent.com/evloghq/evlog/main/assets/evlog-banner.gif" width="100%" alt="evlog — Digging through logs is not observability. It's hope" />
 </p>
 
 # @evlog/telemetry
 
 [![npm version](https://img.shields.io/npm/v/@evlog/telemetry?color=black)](https://npmjs.com/package/@evlog/telemetry)
 [![npm downloads](https://img.shields.io/npm/dm/@evlog/telemetry?color=black)](https://npm.chart.dev/@evlog/telemetry)
-[![CI](https://img.shields.io/github/actions/workflow/status/HugoRCD/evlog/ci.yml?branch=main&color=black)](https://github.com/HugoRCD/evlog/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/evloghq/evlog/ci.yml?branch=main&color=black)](https://github.com/evloghq/evlog/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-black?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://evlog.dev/use-cases/telemetry/overview)
-[![license](https://img.shields.io/github/license/HugoRCD/evlog?color=black)](https://github.com/HugoRCD/evlog/blob/main/LICENSE)
+[![license](https://img.shields.io/github/license/evloghq/evlog?color=black)](https://github.com/evloghq/evlog/blob/main/LICENSE)
 
 **Digging through logs is not observability. It's hope.**
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://evlog.dev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HugoRCD/evlog.git",
+    "url": "git+https://github.com/evloghq/evlog.git",
     "directory": "packages/telemetry"
   },
   "bugs": {
-    "url": "https://github.com/HugoRCD/evlog/issues"
+    "url": "https://github.com/evloghq/evlog/issues"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Prepares the transfer of this repository from `HugoRCD/evlog` to the `evloghq` organization.

Every `hugorcd/evlog` reference now points at `evloghq/evlog`: package metadata (`repository`, `bugs`), READMEs and badges, docs links, issue templates, `SECURITY.md`, the changesets changelog config, Nuxt Studio, and Evi's GitHub owner (clone, push, escalation, extension context). Personal links stay as they are: `author` fields, `FUNDING.yml`, sponsors block, X handle, the maintainer login used for reviews and escalations. CHANGELOGs are left untouched, the old URLs redirect.

Includes a patch changeset for the four packages so the npm metadata picks up the new URLs.

## Merge order

1. Transfer the repository on GitHub (`Settings → Danger Zone → Transfer`).
2. Merge this PR right after. Merging it before the transfer breaks Evi (it would clone a repository that does not exist yet) and the next publish (npm provenance checks `repository.url` against the workflow's repository).
3. Merge the version PR once the GitHub Apps (Vercel, Renovate, pkg.pr.new, Evi) are installed on `evloghq`.
