### PR TITLE
ci: delete neon preview branches on pr close and skip changeset-release deploys

### DIFF
--- a/.github/workflows/neon-preview-cleanup.yml
+++ b/.github/workflows/neon-preview-cleanup.yml
@@ -30,12 +30,27 @@ jobs:
           # workflow_dispatch carries no pull_request payload
           GIT_BRANCH: ${{ github.event.pull_request.head.ref || inputs.branch }}
         run: |
+          set -euo pipefail
+          : "${NEON_API_KEY:?NEON_API_KEY secret is not set}"
+
           name="preview/$GIT_BRANCH"
           api="https://console.neon.tech/api/v2/projects/$NEON_PROJECT_ID/branches"
           auth="Authorization: Bearer $NEON_API_KEY"
 
-          id=$(curl -sf -H "$auth" --get --data-urlencode "search=$name" "$api" \
-            | jq -r --arg name "$name" '.branches[] | select(.name == $name) | .id')
+          id=""
+          cursor=""
+          while :; do
+            set -- --data-urlencode "search=$name" --data-urlencode "limit=100"
+            if [ -n "$cursor" ]; then
+              set -- "$@" --data-urlencode "cursor=$cursor"
+            fi
+            page=$(curl -sf -H "$auth" --get "$@" "$api")
+            id=$(jq -r --arg name "$name" '[.branches[] | select(.name == $name) | .id][0] // empty' <<< "$page")
+            cursor=$(jq -r '.pagination.next // empty' <<< "$page")
+            if [ -n "$id" ] || [ -z "$cursor" ]; then
+              break
+            fi
+          done
 
           if [ -z "$id" ]; then
             echo "No Neon branch named $name"

--- a/.github/workflows/neon-preview-cleanup.yml
+++ b/.github/workflows/neon-preview-cleanup.yml
@@ -1,0 +1,46 @@
+name: delete neon preview branch
+
+# Vercel's Neon integration creates preview/<git-branch> on evi-db for every
+# preview deployment and only drops it with the deployment, months later.
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Git branch whose Neon preview branch should be deleted
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  NEON_PROJECT_ID: floral-dawn-93202365
+
+jobs:
+  cleanup:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Delete the Neon preview branch
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          # workflow_dispatch carries no pull_request payload
+          GIT_BRANCH: ${{ github.event.pull_request.head.ref || inputs.branch }}
+        run: |
+          name="preview/$GIT_BRANCH"
+          api="https://console.neon.tech/api/v2/projects/$NEON_PROJECT_ID/branches"
+          auth="Authorization: Bearer $NEON_API_KEY"
+
+          id=$(curl -sf -H "$auth" --get --data-urlencode "search=$name" "$api" \
+            | jq -r --arg name "$name" '.branches[] | select(.name == $name) | .id')
+
+          if [ -z "$id" ]; then
+            echo "No Neon branch named $name"
+            exit 0
+          fi
+
+          curl -sf -X DELETE -H "$auth" "$api/$id" > /dev/null
+          echo "Deleted $name ($id)"

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-docs --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "sh ../../scripts/vercel-ignore-build.sh evlog-docs"
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-docs --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-docs --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
 }

--- a/apps/evi/vercel.json
+++ b/apps/evi/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evi --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "sh ../../scripts/vercel-ignore-build.sh evi"
 }

--- a/apps/evi/vercel.json
+++ b/apps/evi/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evi --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evi --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
 }

--- a/apps/just-use-evlog/vercel.json
+++ b/apps/just-use-evlog/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-just-use --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "sh ../../scripts/vercel-ignore-build.sh evlog-just-use"
 }

--- a/apps/just-use-evlog/vercel.json
+++ b/apps/just-use-evlog/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-just-use --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-just-use --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
 }

--- a/apps/lab/vercel.json
+++ b/apps/lab/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages render-labs --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "sh ../../scripts/vercel-ignore-build.sh render-labs"
 }

--- a/apps/lab/vercel.json
+++ b/apps/lab/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages render-labs --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages render-labs --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
 }

--- a/apps/nuxthub-playground/vercel.json
+++ b/apps/nuxthub-playground/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-nuxthub-playground --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-nuxthub-playground --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1",
   "crons": [
     {
       "path": "/api/_cron/evlog-cleanup",

--- a/apps/nuxthub-playground/vercel.json
+++ b/apps/nuxthub-playground/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-nuxthub-playground --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1",
+  "ignoreCommand": "sh ../../scripts/vercel-ignore-build.sh evlog-nuxthub-playground",
   "crons": [
     {
       "path": "/api/_cron/evlog-cleanup",

--- a/apps/telemetry/vercel.json
+++ b/apps/telemetry/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-telemetry --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-telemetry --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
 }

--- a/apps/telemetry/vercel.json
+++ b/apps/telemetry/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ] && exit 0; [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git fetch --unshallow >/dev/null 2>&1; npx turbo query affected --packages evlog-telemetry --exit-code --base \"$VERCEL_GIT_PREVIOUS_SHA\" || exit 1"
+  "ignoreCommand": "sh ../../scripts/vercel-ignore-build.sh evlog-telemetry"
 }

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Vercel "Ignored Build Step" for one app: exit 0 skips the build, exit 1 builds.
+# The changesets release branch is never previewed, so it never builds.
+[ "$VERCEL_GIT_COMMIT_REF" = "changeset-release/main" ] && exit 0
+[ -n "$VERCEL_GIT_PREVIOUS_SHA" ] || exit 1
+git fetch --unshallow >/dev/null 2>&1
+npx turbo query affected --packages "$1" --exit-code --base "$VERCEL_GIT_PREVIOUS_SHA" || exit 1


### PR DESCRIPTION
## Summary

- New workflow `neon-preview-cleanup.yml`: when a PR closes, deletes the `preview/<branch>` branch that Vercel's Neon integration created on evi-db. Neon otherwise keeps it until the Vercel deployment expires (180 days), past the 10 branches included in the plan. Needs the `NEON_API_KEY` repository secret. Also runnable by hand with `workflow_dispatch` for a given branch.
- Every `apps/*/vercel.json` ignore command now skips builds on `changeset-release/main`. That branch rebuilt all five Vercel projects about 140 times each in August and created a Neon preview branch for nothing.

No changeset: `apps/*` and `.github` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup of preview database branches when pull requests close, with optional manual cleanup.
  - Cleanup safely handles branches that no longer exist.

- **Chores**
  - Updated deployment checks across supported applications to skip builds for the release branch when no relevant changes are detected.
  - Existing deployment checks remain active for other branches.
  - Standardized deployment-check behavior across supported applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->