### PR TITLE
chore(repo): version packages

### DIFF
--- a/.changeset/move-to-evloghq.md
+++ b/.changeset/move-to-evloghq.md
@@ -1,8 +1,0 @@
----
-"evlog": patch
-"@evlog/cli": patch
-"@evlog/nuxthub": patch
-"@evlog/telemetry": patch
----
-
-Point the package metadata (`repository`, `bugs`) and README links at the repository's new home, `evloghq/evlog`.

--- a/apps/nuxthub-playground/.nuxtrc
+++ b/apps/nuxthub-playground/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@evlog/nuxthub="2.0.1"
+setups.@evlog/nuxthub="2.0.2"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @evlog/cli
 
+## 0.6.2
+
+### Patch Changes
+
+- [#649](https://github.com/evloghq/evlog/pull/649) [`0417784`](https://github.com/evloghq/evlog/commit/0417784dc9e6d3825c10b5d715ff2cb1e7e3acdd) Thanks [@HugoRCD](https://github.com/HugoRCD)! - Point the package metadata (`repository`, `bugs`) and README links at the repository's new home, `evloghq/evlog`.
+
+- Updated dependencies [[`0417784`](https://github.com/evloghq/evlog/commit/0417784dc9e6d3825c10b5d715ff2cb1e7e3acdd)]:
+  - evlog@2.28.1
+  - @evlog/telemetry@0.3.1
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evlog/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The official command line for evlog",
   "author": "HugoRCD <contact@evlog.dev>",
   "homepage": "https://evlog.dev",

--- a/packages/evlog/CHANGELOG.md
+++ b/packages/evlog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # evlog
 
+## 2.28.1
+
+### Patch Changes
+
+- [#649](https://github.com/evloghq/evlog/pull/649) [`0417784`](https://github.com/evloghq/evlog/commit/0417784dc9e6d3825c10b5d715ff2cb1e7e3acdd) Thanks [@HugoRCD](https://github.com/HugoRCD)! - Point the package metadata (`repository`, `bugs`) and README links at the repository's new home, `evloghq/evlog`.
+
 ## 2.28.0
 
 ### Minor Changes

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evlog",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "Modern TypeScript logger — simple logs, wide events, structured errors. Built for scripts, libraries, jobs, edge, and HTTP. One drain pipeline everywhere.",
   "author": "HugoRCD <contact@evlog.dev>",
   "homepage": "https://evlog.dev",

--- a/packages/nuxthub/.nuxtrc
+++ b/packages/nuxthub/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@evlog/nuxthub="2.0.1"
+setups.@evlog/nuxthub="2.0.2"

--- a/packages/nuxthub/CHANGELOG.md
+++ b/packages/nuxthub/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @evlog/nuxthub
 
+## 2.0.2
+
+### Patch Changes
+
+- [#649](https://github.com/evloghq/evlog/pull/649) [`0417784`](https://github.com/evloghq/evlog/commit/0417784dc9e6d3825c10b5d715ff2cb1e7e3acdd) Thanks [@HugoRCD](https://github.com/HugoRCD)! - Point the package metadata (`repository`, `bugs`) and README links at the repository's new home, `evloghq/evlog`.
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/nuxthub/package.json
+++ b/packages/nuxthub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evlog/nuxthub",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Self-hosted log retention for evlog using NuxtHub database storage",
   "author": "HugoRCD <contact@evlog.dev>",
   "homepage": "https://evlog.dev",

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @evlog/telemetry
 
+## 0.3.1
+
+### Patch Changes
+
+- [#649](https://github.com/evloghq/evlog/pull/649) [`0417784`](https://github.com/evloghq/evlog/commit/0417784dc9e6d3825c10b5d715ff2cb1e7e3acdd) Thanks [@HugoRCD](https://github.com/HugoRCD)! - Point the package metadata (`repository`, `bugs`) and README links at the repository's new home, `evloghq/evlog`.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evlog/telemetry",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Wide-event telemetry for CLIs and automation — evlog's one-event-per-run model for tools on user machines, with privacy-safe flags, consent, outbox, and auto disclosure",
   "author": "HugoRCD <contact@evlog.dev>",
   "homepage": "https://evlog.dev",


### PR DESCRIPTION
Patch release of evlog, @evlog/cli, @evlog/nuxthub and @evlog/telemetry: package metadata and README links now point at evloghq/evlog.

Opened by hand: the release workflow could not create it because the organization does not yet allow GitHub Actions to create pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated package metadata and README links to reflect the repository’s new home: `evloghq/evlog`.
  - Added release notes for the latest package versions.

- **Chores**
  - Published patch updates across the CLI, core package, NuxtHub integration, and telemetry package.
  - Updated package references to compatible dependency versions.
  - Updated NuxtHub setup configurations to use version 2.0.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->