### PR TITLE
fix(evi): pin the evloghq github app installation

### DIFF
--- a/apps/evi/agent/extensions/github.ts
+++ b/apps/evi/agent/extensions/github.ts
@@ -1,6 +1,6 @@
 import githubExtension from '@github-tools/eve-extension'
 import type { ApprovalContext, ApprovalStatus } from 'eve/tools/approval'
-import { GITHUB_CONNECTOR } from '../lib/github/credentials'
+import { GITHUB_CONNECTOR, GITHUB_INSTALLATION_ID } from '../lib/github/credentials'
 import { createLabelPolicy, writePolicy } from '../lib/github/label-approval'
 import { isAutonomous, isScheduleAppAuth, MAINTAINER_GITHUB_LOGIN } from '../lib/trust'
 
@@ -93,6 +93,7 @@ function assignPolicy(ctx: ApprovalContext): ApprovalStatus {
 
 export default githubExtension({
   connector: GITHUB_CONNECTOR,
+  connect: { installationId: GITHUB_INSTALLATION_ID },
   context: { owner: 'evloghq', repo: 'evlog' },
   include: [...TOOLS],
   // Omitted write tools keep the default always(): closeIssue, createPullRequestReview.

--- a/apps/evi/agent/lib/github/credentials.ts
+++ b/apps/evi/agent/lib/github/credentials.ts
@@ -3,4 +3,8 @@ import { connectGitHubCredentials } from '@vercel/connect/eve'
 /** The Connect connector shared by the GitHub channel, the extension, and the push tool. */
 export const GITHUB_CONNECTOR = 'github/evi-github-production'
 
-export const githubCredentials = connectGitHubCredentials(GITHUB_CONNECTOR)
+// The connector's default installation is the retired one on the maintainer's
+// account, and Connect exposes no way to change it: pin the evloghq one.
+export const GITHUB_INSTALLATION_ID = '158603310'
+
+export const githubCredentials = connectGitHubCredentials(GITHUB_CONNECTOR, { installationId: GITHUB_INSTALLATION_ID })


### PR DESCRIPTION
After the transfer to evloghq, the Connect connector `github/evi-github-production` still defaults to installation 151305407, the retired one on the maintainer's account: "Test App Token" in the Connect dashboard mints a token on it, and there is no way to change the default through the dashboard or the API. Every token Evi minted would be blind to `evloghq/evlog`.

The credentials helper and the GitHub extension now pass the evloghq installation (158603310) explicitly.

Checked locally: `tsc`, vitest (200 tests), eslint, and `eve build` on Node 24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub connections now consistently use the configured installation, improving reliability when accessing GitHub through the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->