### PR TITLE
fix(evi): post one github comment per @evlogai mention

### DIFF
--- a/apps/evi/agent/extensions/github.ts
+++ b/apps/evi/agent/extensions/github.ts
@@ -2,6 +2,7 @@ import githubExtension from '@github-tools/eve-extension'
 import type { ApprovalContext, ApprovalStatus } from 'eve/tools/approval'
 import { GITHUB_CONNECTOR, GITHUB_INSTALLATION_ID } from '../lib/github/credentials'
 import { createLabelPolicy, writePolicy } from '../lib/github/label-approval'
+import { threadCommentPolicy } from '../lib/github/thread-comment'
 import { isAutonomous, isScheduleAppAuth, MAINTAINER_GITHUB_LOGIN } from '../lib/trust'
 
 /**
@@ -113,7 +114,8 @@ export default githubExtension({
     updatePullRequest: policy,
     createIssue: autonomousWrite,
     updateIssue: policy,
-    addIssueComment: policy,
+    addIssueComment: (ctx: ApprovalContext) =>
+      threadCommentPolicy(ctx.session.auth.current, ctx.toolInput),
     updateIssueComment: policy,
     addPullRequestComment: policy,
     updatePullRequestComment: policy,

--- a/apps/evi/agent/instructions/github.ts
+++ b/apps/evi/agent/instructions/github.ts
@@ -1,0 +1,13 @@
+import { defineDynamic, defineInstructions } from 'eve/instructions'
+import { channelName } from '../lib/channel'
+
+const GITHUB = `## GitHub
+
+Your reply is the comment: the channel posts it verbatim on this thread when the turn finishes. Write one reply and stop. Do not call \`github__addIssueComment\` on this issue or pull request; that posts a second comment next to the one the channel already delivers. Use that tool only for a different thread. Progress on this channel is the eyes reaction on the mention, not a status comment.`
+
+export default defineDynamic({
+  events: {
+    'turn.started': (_event, ctx) =>
+      channelName(ctx.channel.kind) === 'github' ? defineInstructions({ content: GITHUB }) : null,
+  },
+})

--- a/apps/evi/agent/lib/github/thread-comment.test.ts
+++ b/apps/evi/agent/lib/github/thread-comment.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SessionAuthContext } from 'eve/context'
+
+function auth(overrides: Partial<SessionAuthContext>): SessionAuthContext {
+  return {
+    attributes: {},
+    authenticator: 'test',
+    principalId: 'test:none',
+    principalType: 'user',
+    ...overrides,
+  }
+}
+
+function githubAuth(overrides: Partial<SessionAuthContext> = {}): SessionAuthContext {
+  return auth({
+    authenticator: 'github-webhook',
+    principalId: 'github:12345',
+    attributes: { issue_number: '654', pull_request_number: '', ...overrides.attributes },
+    ...overrides,
+  })
+}
+
+async function load(env: Record<string, string | undefined> = {}) {
+  vi.resetModules()
+  vi.stubEnv('VERCEL_ENV', 'production')
+  vi.stubEnv('EVE_RUN_MODE', undefined)
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) vi.stubEnv(key, '')
+    else vi.stubEnv(key, value)
+  }
+  return await import('./thread-comment')
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('threadCommentPolicy', () => {
+  it('denies commenting on the current GitHub thread, even for the maintainer', async () => {
+    const { threadCommentPolicy } = await load({ MAINTAINER_GITHUB_ID: '12345' })
+    const current = githubAuth()
+    expect(threadCommentPolicy(current, { issueNumber: 654, body: 'hello' })).toEqual({
+      type: 'denied',
+      reason: expect.stringContaining('already posts your reply'),
+    })
+    expect(threadCommentPolicy(current, { body: 'hello' })).toEqual({
+      type: 'denied',
+      reason: expect.stringContaining('already posts your reply'),
+    })
+  })
+
+  it('denies when the GitHub session has no thread number to compare', async () => {
+    const { threadCommentPolicy } = await load({ MAINTAINER_GITHUB_ID: '12345' })
+    expect(threadCommentPolicy(
+      githubAuth({ attributes: { issue_number: '', pull_request_number: '' } }),
+      { issueNumber: 1, body: 'hello' },
+    )).toEqual({
+      type: 'denied',
+      reason: expect.stringContaining('already posts your reply'),
+    })
+  })
+
+  it('allows a comment on a different issue, still gated by writePolicy', async () => {
+    const { threadCommentPolicy } = await load({ MAINTAINER_GITHUB_ID: '12345' })
+    expect(threadCommentPolicy(
+      githubAuth(),
+      { issueNumber: 660, body: 'pointer' },
+    )).toBe('not-applicable')
+    expect(threadCommentPolicy(
+      githubAuth({ principalId: 'github:99999' }),
+      { issueNumber: 660, body: 'pointer' },
+    )).toBe('user-approval')
+  })
+
+  it('does not treat a Slack session as a GitHub thread', async () => {
+    const { threadCommentPolicy } = await load({ MAINTAINER_GITHUB_ID: '12345' })
+    expect(threadCommentPolicy(
+      auth({
+        authenticator: 'slack-webhook',
+        principalId: 'github:12345',
+        attributes: { issue_number: '654' },
+      }),
+      { issueNumber: 654, body: 'from slack' },
+    )).toBe('not-applicable')
+  })
+
+  it('matches snake_case and pull-request numbers on the same thread', async () => {
+    const { threadCommentPolicy } = await load({ MAINTAINER_GITHUB_ID: '12345' })
+    expect(threadCommentPolicy(
+      githubAuth({ attributes: { issue_number: '660', pull_request_number: '660' } }),
+      { pull_request_number: 660, body: 'on the pr' },
+    )).toEqual({
+      type: 'denied',
+      reason: expect.stringContaining('already posts your reply'),
+    })
+  })
+})

--- a/apps/evi/agent/lib/github/thread-comment.ts
+++ b/apps/evi/agent/lib/github/thread-comment.ts
@@ -1,0 +1,64 @@
+import type { SessionAuthContext } from 'eve/context'
+import type { ApprovalStatus } from 'eve/tools/approval'
+import { writePolicy } from './label-approval'
+
+const DENIED: ApprovalStatus = {
+  type: 'denied',
+  reason: 'The GitHub channel already posts your reply as the comment on this thread. Put the reply in your final message; use this tool only for a different issue.',
+}
+
+const INPUT_NUMBER_KEYS = [
+  'issueNumber',
+  'issue_number',
+  'pullRequestNumber',
+  'pull_request_number',
+] as const
+
+const AUTH_NUMBER_KEYS = ['issue_number', 'pull_request_number'] as const
+
+/**
+ * On a GitHub-channel turn the reply is posted by `message.completed`, so
+ * `addIssueComment` on this thread is a second comment. Other channels and a
+ * comment aimed at a different issue still go through {@link writePolicy}.
+ */
+export function threadCommentPolicy(
+  auth: SessionAuthContext | null,
+  toolInput?: unknown,
+): ApprovalStatus {
+  if (auth?.authenticator !== 'github-webhook') return writePolicy(auth)
+  const current = threadNumbersFromAuth(auth)
+  if (current.size === 0) return DENIED
+  const target = issueNumberFromInput(toolInput)
+  if (target === null || current.has(target)) return DENIED
+  return writePolicy(auth)
+}
+
+export function threadNumbersFromAuth(auth: SessionAuthContext | null): Set<number> {
+  const numbers = new Set<number>()
+  if (auth === null) return numbers
+  const attributes = auth.attributes as Record<string, unknown>
+  for (const key of AUTH_NUMBER_KEYS) {
+    const parsed = parseIssueNumber(attributes[key])
+    if (parsed !== null) numbers.add(parsed)
+  }
+  return numbers
+}
+
+export function issueNumberFromInput(toolInput: unknown): number | null {
+  if (toolInput === null || toolInput === undefined || typeof toolInput !== 'object') return null
+  const input = toolInput as Record<string, unknown>
+  for (const key of INPUT_NUMBER_KEYS) {
+    const parsed = parseIssueNumber(input[key])
+    if (parsed !== null) return parsed
+  }
+  return null
+}
+
+function parseIssueNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const parsed = Number(value)
+    return parsed > 0 ? parsed : null
+  }
+  return null
+}

--- a/apps/evi/docs/notes.md
+++ b/apps/evi/docs/notes.md
@@ -126,6 +126,14 @@ name.
 **`*Context` tools collapse round-trips.** `getIssueContext` returns the issue,
 its labels and recent comments in one call.
 
+**`addIssueComment` on the current thread is a second comment.** The channel's
+`message.completed` handler posts the final reply unless `finishReason` is
+`tool-calls` (progress is the eyes reaction). A maintainer mention that also
+calls `github__addIssueComment` therefore lands two comments, which is what
+happened on #654. `threadCommentPolicy` denies that tool on `github-webhook`
+sessions targeting this thread; Slack and a comment on a different issue still
+go through `writePolicy`.
+
 ## Vercel Connect
 
 **Connector types are not interchangeable.** The Linear channel is type `Linear`


### PR DESCRIPTION
On GitHub, eve already posts the final reply via message.completed. addIssueComment on the same thread produced a second comment on every @evlogai mention (#654). threadCommentPolicy now denies that same-thread write; a GitHub instruction fragment tells the model the channel post is the reply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub thread replies are now posted directly as a single comment.
  - Progress on GitHub conversations is represented with an eyes reaction.
  - Commenting behavior now distinguishes between the current thread and other issues or pull requests.

- **Bug Fixes**
  - Prevented duplicate comments from being posted to the active GitHub thread.
  - GitHub comment approvals now respect the current authentication and write permissions.

- **Documentation**
  - Added guidance explaining GitHub comment behavior and duplicate-comment prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->