### PR TITLE
fix(docs): recover from stale nuxt chunk loads

### DIFF
--- a/apps/docs/app/plugins/chunk-reload.client.ts
+++ b/apps/docs/app/plugins/chunk-reload.client.ts
@@ -1,0 +1,19 @@
+/**
+ * `experimental.emitRouteChunkError: 'automatic-immediate'` already reloads
+ * when Nuxt sees `app:chunkError` (the `vite:preloadError` path). Firefox and
+ * Safari often surface the same stale `/_nuxt` import as an unhandled
+ * rejection instead, which never reaches that hook and leaves the page
+ * broken. Recover those the same way Nuxt recovers route-chunk failures.
+ */
+export default defineNuxtPlugin(() => {
+  if (import.meta.dev) return
+
+  const recover = (error: unknown) => {
+    if (!isChunkLoadError(error)) return
+    reloadNuxtApp({ persistState: true })
+  }
+
+  window.addEventListener('unhandledrejection', (event) => {
+    recover(event.reason)
+  })
+})

--- a/apps/docs/app/utils/chunk-load-error.ts
+++ b/apps/docs/app/utils/chunk-load-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Browsers phrase a failed dynamic `import()` differently. These are the
+ * messages PostHog recorded for stale `/_nuxt/*.js` after a docs deploy.
+ */
+const CHUNK_LOAD_MARKERS = [
+  'Failed to fetch dynamically imported module',
+  'error loading dynamically imported module',
+  'Importing a module script failed',
+] as const
+
+function messageOf(error: unknown): string {
+  if (typeof error === 'string') return error
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error.message
+  }
+  return ''
+}
+
+/** True when `error` is a failed dynamic import, usually a stale hashed chunk. */
+export function isChunkLoadError(error: unknown): boolean {
+  const message = messageOf(error)
+  return CHUNK_LOAD_MARKERS.some(marker => message.includes(marker))
+}

--- a/apps/docs/app/utils/chunk-load-error.ts
+++ b/apps/docs/app/utils/chunk-load-error.ts
@@ -10,7 +10,6 @@ const CHUNK_LOAD_MARKERS = [
 
 function messageOf(error: unknown): string {
   if (typeof error === 'string') return error
-  if (error instanceof Error) return error.message
   if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
     return error.message
   }

--- a/apps/docs/test/chunk-load-error.test.ts
+++ b/apps/docs/test/chunk-load-error.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { isChunkLoadError } from '../app/utils/chunk-load-error'
+
+describe('isChunkLoadError', () => {
+  it.each([
+    'Failed to fetch dynamically imported module: https://www.evlog.dev/_nuxt/DgnQ7b28.js',
+    'error loading dynamically imported module: https://www.evlog.dev/_nuxt/WcfzClUS.js',
+    'Importing a module script failed.',
+  ])('matches %s', (message) => {
+    expect(isChunkLoadError(new TypeError(message))).toBe(true)
+    expect(isChunkLoadError(message)).toBe(true)
+  })
+
+  it('ignores first-party exceptions', () => {
+    expect(isChunkLoadError(new TypeError('Cannot read properties of undefined (reading \'id\')'))).toBe(false)
+    expect(isChunkLoadError(new Error('Script error.'))).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

No open issue tracks this; found through error tracking.

### 📚 Description

**Problem**
- After a docs deploy, visitors still on the previous JS try to `import()` hashed `/_nuxt/*.js` files that no longer exist.
- PostHog shows several TypeError groups (`Failed to fetch dynamically imported module`, `error loading dynamically imported module`, `Importing a module script failed`) for chunks such as `DgnQ7b28.js`, `WcfzClUS.js`, `DyPGqKT-.js`.
- `#424` already set `experimental.emitRouteChunkError: 'automatic-immediate'`. That reloads when Nuxt sees `app:chunkError` (`vite:preloadError`). Firefox and Safari often surface the same failure as an unhandled rejection, which never reaches that hook, so the page stays broken.
- The inbox hint at `npmx / modules/isr-fallback.ts` is the wrong product (Next.js). This app is Nuxt 4 / Docus.

**Change**
- Keep `emitRouteChunkError: 'automatic-immediate'` as the route/`app:chunkError` path.
- Add a client plugin that calls `reloadNuxtApp({ persistState: true })` when an unhandled rejection matches the three chunk-load messages above. `reloadNuxtApp` already ignores a second reload of the same path for 10s, so this does not loop with the built-in handler.
- Recovery path: failed dynamic import → `unhandledrejection` → `isChunkLoadError` → `reloadNuxtApp` → fresh HTML (already `must-revalidate`) with the current chunk hashes.

**Not in this PR**
- These errors will still appear in error tracking (capture happens before the reload). Filtering them is a separate change.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d5ee164-a492-405b-9ccc-00fb1feb9978?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d5ee164-a492-405b-9ccc-00fb1feb9978&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The documentation app now automatically reloads when a required code update cannot be loaded, helping users recover without manually refreshing.
  - Application state is preserved during recovery where possible.
  - Unrelated errors are left unchanged, and this behavior remains limited to production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->