### PR TITLE
fix(docs): drop cross-origin script errors before ingestion

### DIFF
--- a/apps/docs/app/plugins/posthog.client.ts
+++ b/apps/docs/app/plugins/posthog.client.ts
@@ -1,27 +1,5 @@
-import posthog, { type CaptureResult } from 'posthog-js'
-
-/**
- * Uncaught errors from browser extensions surface through `capture_exceptions`
- * even though the site does not own that injected code. A stack frame served
- * over one of these schemes is one tell; an extension-only API named in the
- * message is the other, and the only one when the error carries no frames.
- */
-const EXTENSION_FRAME_SCHEMES = ['chrome-extension://', 'moz-extension://', 'safari-web-extension://']
-const EXTENSION_API_MARKERS = ['runtime.sendMessage', 'chrome.runtime', 'browser.runtime']
-
-function isExtensionException(properties: CaptureResult['properties']): boolean {
-  const exceptions = properties?.$exception_list
-  if (!Array.isArray(exceptions)) return false
-
-  return exceptions.some((exception) => {
-    const frames = exception?.stacktrace?.frames
-    if (Array.isArray(frames) && frames.some((frame) => EXTENSION_FRAME_SCHEMES.some((scheme) => frame?.filename?.startsWith(scheme)))) {
-      return true
-    }
-    const message = `${exception?.type ?? ''} ${exception?.value ?? ''}`
-    return EXTENSION_API_MARKERS.some((marker) => message.includes(marker))
-  })
-}
+import posthog from 'posthog-js'
+import { shouldDropCapturedException } from '../utils/posthog-exceptions'
 
 /**
  * Consent-tiered analytics: while consent is pending or refused, PostHog runs
@@ -53,10 +31,11 @@ export default defineNuxtPlugin(() => {
     // Off in the local dev server: a Vite module error or any other dev-only
     // failure must not ship to the same error tracking project as production.
     capture_exceptions: !import.meta.dev,
-    // Drop uncaught exceptions thrown by browser extensions on the page; they
-    // are not the site's code and only add noise to error tracking.
+    // Drop uncaught exceptions that are not the site's code: browser
+    // extensions, and classic cross-origin `Script error.` / Firefox
+    // permission-denied events with no first-party frames.
     before_send: (event) => {
-      if (event?.event === '$exception' && isExtensionException(event.properties)) return null
+      if (event?.event === '$exception' && shouldDropCapturedException(event.properties)) return null
       return event
     },
   })

--- a/apps/docs/app/utils/posthog-exceptions.ts
+++ b/apps/docs/app/utils/posthog-exceptions.ts
@@ -1,0 +1,74 @@
+/**
+ * Uncaught errors from browser extensions surface through `capture_exceptions`
+ * even though the site does not own that injected code. A stack frame served
+ * over one of these schemes is one tell; an extension-only API named in the
+ * message is the other, and the only one when the error carries no frames.
+ */
+const EXTENSION_FRAME_SCHEMES = ['chrome-extension://', 'moz-extension://', 'safari-web-extension://']
+const EXTENSION_API_MARKERS = ['runtime.sendMessage', 'chrome.runtime', 'browser.runtime']
+
+/**
+ * Classic cross-origin noise: the browser strips the real message and stack.
+ * `Script error.` is the window.onerror form; Firefox reports the same class
+ * as `Permission denied to access object` with only the autocapture frame.
+ */
+const CROSS_ORIGIN_MESSAGES = new Set([
+  'Script error.',
+  'Script error',
+  'Permission denied to access object',
+])
+const NON_SITE_FRAME_MARKERS = [
+  ...EXTENSION_FRAME_SCHEMES,
+  'exception-autocapture',
+]
+
+export interface CapturedException {
+  type?: string
+  value?: string
+  stacktrace?: {
+    frames?: Array<{ filename?: string }>
+  }
+}
+
+export interface CapturedExceptionProperties {
+  $exception_list?: CapturedException[]
+}
+
+export function isExtensionException(properties: CapturedExceptionProperties | undefined): boolean {
+  const exceptions = properties?.$exception_list
+  if (!Array.isArray(exceptions)) return false
+
+  return exceptions.some((exception) => {
+    const frames = exception?.stacktrace?.frames
+    if (Array.isArray(frames) && frames.some(frame => EXTENSION_FRAME_SCHEMES.some(scheme => frame?.filename?.startsWith(scheme)))) {
+      return true
+    }
+    const message = `${exception?.type ?? ''} ${exception?.value ?? ''}`
+    return EXTENSION_API_MARKERS.some(marker => message.includes(marker))
+  })
+}
+
+export function isCrossOriginException(properties: CapturedExceptionProperties | undefined): boolean {
+  const exceptions = properties?.$exception_list
+  if (!Array.isArray(exceptions)) return false
+
+  return exceptions.some((exception) => {
+    if (!CROSS_ORIGIN_MESSAGES.has(exception?.value ?? '')) return false
+    return !hasSiteFrame(exception)
+  })
+}
+
+/** Drop `$exception` events that are not the site's code. */
+export function shouldDropCapturedException(properties: CapturedExceptionProperties | undefined): boolean {
+  return isExtensionException(properties) || isCrossOriginException(properties)
+}
+
+function hasSiteFrame(exception: CapturedException): boolean {
+  const frames = exception.stacktrace?.frames
+  if (!Array.isArray(frames) || frames.length === 0) return false
+
+  return frames.some((frame) => {
+    const filename = frame?.filename ?? ''
+    return filename.length > 0 && !NON_SITE_FRAME_MARKERS.some(marker => filename.includes(marker))
+  })
+}

--- a/apps/docs/test/posthog-exceptions.test.ts
+++ b/apps/docs/test/posthog-exceptions.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isCrossOriginException,
+  isExtensionException,
+  shouldDropCapturedException,
+} from '../app/utils/posthog-exceptions'
+
+describe('isExtensionException', () => {
+  it('drops a chrome-extension stack frame', () => {
+    expect(isExtensionException({
+      $exception_list: [{
+        type: 'Error',
+        value: 'boom',
+        stacktrace: { frames: [{ filename: 'chrome-extension://abc/content.js' }] },
+      }],
+    })).toBe(true)
+  })
+
+  it('drops an extension-only API named in the message when there are no frames', () => {
+    expect(isExtensionException({
+      $exception_list: [{ type: 'Error', value: 'Invalid call to runtime.sendMessage(). Tab not found.' }],
+    })).toBe(true)
+  })
+
+  it('keeps a first-party exception', () => {
+    expect(isExtensionException({
+      $exception_list: [{
+        type: 'TypeError',
+        value: 'Cannot read properties of undefined (reading \'id\')',
+        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+      }],
+    })).toBe(false)
+  })
+})
+
+describe('isCrossOriginException', () => {
+  it('drops Script error. with no frames', () => {
+    expect(isCrossOriginException({
+      $exception_list: [{ type: 'Error', value: 'Script error.' }],
+    })).toBe(true)
+  })
+
+  it('drops Firefox permission-denied when the only frame is exception-autocapture', () => {
+    expect(isCrossOriginException({
+      $exception_list: [{
+        type: 'Error',
+        value: 'Permission denied to access object',
+        stacktrace: { frames: [{ filename: '../src/entrypoints/exception-autocapture.ts' }] },
+      }],
+    })).toBe(true)
+  })
+
+  it('keeps a first-party exception even if the message mentions permission', () => {
+    expect(isCrossOriginException({
+      $exception_list: [{
+        type: 'Error',
+        value: 'Permission denied to write file',
+        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+      }],
+    })).toBe(false)
+  })
+
+  it('keeps Permission denied to access object when a site frame is present', () => {
+    expect(isCrossOriginException({
+      $exception_list: [{
+        type: 'Error',
+        value: 'Permission denied to access object',
+        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+      }],
+    })).toBe(false)
+  })
+})
+
+describe('shouldDropCapturedException', () => {
+  it('drops extension and cross-origin events, keeps site-owned ones', () => {
+    expect(shouldDropCapturedException({
+      $exception_list: [{ type: 'Error', value: 'Script error.' }],
+    })).toBe(true)
+    expect(shouldDropCapturedException({
+      $exception_list: [{ type: 'Error', value: 'Invalid call to runtime.sendMessage(). Tab not found.' }],
+    })).toBe(true)
+    expect(shouldDropCapturedException({
+      $exception_list: [{
+        type: 'TypeError',
+        value: 'Cannot read properties of undefined (reading \'id\')',
+        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+      }],
+    })).toBe(false)
+  })
+})

--- a/apps/docs/test/posthog-exceptions.test.ts
+++ b/apps/docs/test/posthog-exceptions.test.ts
@@ -8,11 +8,13 @@ import {
 describe('isExtensionException', () => {
   it('drops a chrome-extension stack frame', () => {
     expect(isExtensionException({
-      $exception_list: [{
-        type: 'Error',
-        value: 'boom',
-        stacktrace: { frames: [{ filename: 'chrome-extension://abc/content.js' }] },
-      }],
+      $exception_list: [
+        {
+          type: 'Error',
+          value: 'boom',
+          stacktrace: { frames: [{ filename: 'chrome-extension://abc/content.js' }] },
+        }
+      ],
     })).toBe(true)
   })
 
@@ -24,11 +26,13 @@ describe('isExtensionException', () => {
 
   it('keeps a first-party exception', () => {
     expect(isExtensionException({
-      $exception_list: [{
-        type: 'TypeError',
-        value: 'Cannot read properties of undefined (reading \'id\')',
-        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
-      }],
+      $exception_list: [
+        {
+          type: 'TypeError',
+          value: 'Cannot read properties of undefined (reading \'id\')',
+          stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+        }
+      ],
     })).toBe(false)
   })
 })
@@ -42,31 +46,37 @@ describe('isCrossOriginException', () => {
 
   it('drops Firefox permission-denied when the only frame is exception-autocapture', () => {
     expect(isCrossOriginException({
-      $exception_list: [{
-        type: 'Error',
-        value: 'Permission denied to access object',
-        stacktrace: { frames: [{ filename: '../src/entrypoints/exception-autocapture.ts' }] },
-      }],
+      $exception_list: [
+        {
+          type: 'Error',
+          value: 'Permission denied to access object',
+          stacktrace: { frames: [{ filename: '../src/entrypoints/exception-autocapture.ts' }] },
+        }
+      ],
     })).toBe(true)
   })
 
   it('keeps a first-party exception even if the message mentions permission', () => {
     expect(isCrossOriginException({
-      $exception_list: [{
-        type: 'Error',
-        value: 'Permission denied to write file',
-        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
-      }],
+      $exception_list: [
+        {
+          type: 'Error',
+          value: 'Permission denied to write file',
+          stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+        }
+      ],
     })).toBe(false)
   })
 
   it('keeps Permission denied to access object when a site frame is present', () => {
     expect(isCrossOriginException({
-      $exception_list: [{
-        type: 'Error',
-        value: 'Permission denied to access object',
-        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
-      }],
+      $exception_list: [
+        {
+          type: 'Error',
+          value: 'Permission denied to access object',
+          stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+        }
+      ],
     })).toBe(false)
   })
 })
@@ -80,11 +90,13 @@ describe('shouldDropCapturedException', () => {
       $exception_list: [{ type: 'Error', value: 'Invalid call to runtime.sendMessage(). Tab not found.' }],
     })).toBe(true)
     expect(shouldDropCapturedException({
-      $exception_list: [{
-        type: 'TypeError',
-        value: 'Cannot read properties of undefined (reading \'id\')',
-        stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
-      }],
+      $exception_list: [
+        {
+          type: 'TypeError',
+          value: 'Cannot read properties of undefined (reading \'id\')',
+          stacktrace: { frames: [{ filename: 'https://www.evlog.dev/_nuxt/app.js' }] },
+        }
+      ],
     })).toBe(false)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

No open issue tracks this; found through error tracking. Follow-up to #569.

Inbox: https://eu.posthog.com/project/245589/inbox/01a01ceb-b9d7-77f3-8903-6c8113bb3298

### 📚 Description

**Problem**
- `#569` already drops browser-extension `$exception` events in `before_send`. Cross-origin noise still lands in error tracking:
  - `Script error.` (empty stack, Safari / Mobile Safari) — 10 occ / 6 users in 30d
  - `Permission denied to access object` (Firefox; the only frame is `exception-autocapture.ts`)
- Both are the browser stripping a third-party script. There is nothing to fix on evlog.dev.

**Change**
- Widen the existing `before_send` in `apps/docs/app/plugins/posthog.client.ts`. The predicates live in `app/utils/posthog-exceptions.ts` so the tests can import them.
- Drop `$exception` events whose value is `Script error.` / `Script error` / `Permission denied to access object` **and** that have no first-party stack frame.
- The #569 extension filter is unchanged (chrome/moz/safari-web-extension frames, and `runtime.sendMessage` / `chrome.runtime` / `browser.runtime` in the message).
- A site-owned exception with a `/_nuxt` frame still captures, including a permission-denied message that actually points at site code.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d5ee164-a492-405b-9ccc-00fb1feb9978?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d5ee164-a492-405b-9ccc-00fb1feb9978&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception filtering to exclude browser-extension errors and certain cross-origin browser errors without first-party stack frames.
  * Preserved capture of exceptions originating from the site.

* **Tests**
  * Added coverage for extension errors, cross-origin errors, and first-party exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->