### PR TITLE
fix(evi): recover glm xml tool calls leaked as slack text

### DIFF
--- a/apps/evi/agent/agent.ts
+++ b/apps/evi/agent/agent.ts
@@ -1,6 +1,8 @@
 import type { SessionAuthContext } from 'eve/context'
 import { defineAgent, defineDynamic } from 'eve'
 import { gatewayRouting, sessionTags } from './lib/gateway'
+import { wrapGlmXmlModel } from './lib/glm-xml-middleware'
+import { usesGlmXmlProtocol } from './lib/glm-xml'
 import { MODEL } from './lib/model'
 import { isScheduleAppAuth } from './lib/trust'
 
@@ -29,6 +31,17 @@ function selectModel(_event: unknown, ctx: ModelContext) {
   return { model: MODEL, modelOptions: modelOptions(ctx) }
 }
 
+/**
+ * Session/turn selections must stay model-id strings. A live LanguageModel
+ * (the GLM XML recovery wrap) is only legal on step.started.
+ */
+function selectStepModel(_event: unknown, ctx: ModelContext) {
+  return {
+    model: usesGlmXmlProtocol(MODEL) ? wrapGlmXmlModel(MODEL) : MODEL,
+    modelOptions: modelOptions(ctx),
+  }
+}
+
 export default defineAgent({
   // Also on turn.started: a session whose process died before the selection
   // committed resumes with none, and eve fails the turn rather than guess.
@@ -36,6 +49,7 @@ export default defineAgent({
     events: {
       'session.started': selectModel,
       'turn.started': selectModel,
+      'step.started': selectStepModel,
     },
   }),
   reasoning: 'high',

--- a/apps/evi/agent/lib/glm-xml-middleware.test.ts
+++ b/apps/evi/agent/lib/glm-xml-middleware.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { recoverGlmXmlContent, rewriteGlmXmlStream } from './glm-xml-middleware'
+
+describe('recoverGlmXmlContent', () => {
+  it('turns text XML into tool-call parts and keeps the prose', () => {
+    const { content, recovered } = recoverGlmXmlContent([
+      {
+        type: 'text',
+        text: 'On it.\n<tool_call>linear__list_issues<arg_key>limit</arg_key><arg_value>20</arg_value></tool_call>',
+      },
+    ])
+    expect(recovered).toBe(1)
+    expect(content).toEqual([
+      { type: 'text', text: 'On it.' },
+      {
+        type: 'tool-call',
+        toolCallId: expect.stringMatching(/^glmxml_/),
+        toolName: 'linear__list_issues',
+        input: '{"limit":20}',
+      },
+    ])
+  })
+
+  it('passes native tool-call parts through', () => {
+    const native = { type: 'tool-call' as const, toolCallId: 'call_1', toolName: 'bash', input: '{}' }
+    const { content, recovered } = recoverGlmXmlContent([native])
+    expect(recovered).toBe(0)
+    expect(content).toEqual([native])
+  })
+})
+
+describe('rewriteGlmXmlStream', () => {
+  it('replaces leaked XML text-deltas with tool-call chunks', () => {
+    const rewritten = rewriteGlmXmlStream([
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'Hi. <tool_call>docs__get-page<arg_key>path</arg_key><arg_value>/chat</arg_value></tool_call>' },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: undefined },
+        usage: {
+          inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 4, text: 4, reasoning: undefined },
+        },
+      },
+    ])
+
+    expect(rewritten.filter(chunk => chunk.type === 'text-delta')).toEqual([{ type: 'text-delta', id: 't1', delta: 'Hi.' },])
+    expect(rewritten.some(chunk => chunk.type === 'tool-call' && chunk.toolName === 'docs__get-page')).toBe(true)
+    const finish = rewritten.find(chunk => chunk.type === 'finish')
+    expect(finish?.type === 'finish' && finish.finishReason.unified).toBe('tool-calls')
+  })
+})

--- a/apps/evi/agent/lib/glm-xml-middleware.ts
+++ b/apps/evi/agent/lib/glm-xml-middleware.ts
@@ -1,0 +1,126 @@
+import { gateway, wrapLanguageModel } from 'ai'
+import type { LanguageModelMiddleware } from 'ai'
+import type { LanguageModelV4Content, LanguageModelV4StreamPart } from '@ai-sdk/provider'
+import { extractGlmXml } from './glm-xml'
+
+let callSeq = 0
+
+function nextToolCallId(): string {
+  callSeq += 1
+  return `glmxml_${callSeq.toString(36)}`
+}
+
+function asToolCallPart(name: string, args: Record<string, unknown>): LanguageModelV4Content {
+  return {
+    type: 'tool-call',
+    toolCallId: nextToolCallId(),
+    toolName: name,
+    input: JSON.stringify(args),
+  }
+}
+
+export function recoverGlmXmlContent(content: LanguageModelV4Content[]): {
+  content: LanguageModelV4Content[]
+  recovered: number
+} {
+  const out: LanguageModelV4Content[] = []
+  let recovered = 0
+  for (const part of content) {
+    if (part.type !== 'text') {
+      out.push(part)
+      continue
+    }
+    const { text, calls } = extractGlmXml(part.text)
+    if (text) out.push({ ...part, text })
+    for (const call of calls) {
+      recovered += 1
+      out.push(asToolCallPart(call.name, call.args))
+    }
+  }
+  return { content: out, recovered }
+}
+
+export function rewriteGlmXmlStream(chunks: LanguageModelV4StreamPart[]): LanguageModelV4StreamPart[] {
+  const texts: string[] = []
+  const passthrough: LanguageModelV4StreamPart[] = []
+  let finish: Extract<LanguageModelV4StreamPart, { type: 'finish' }> | undefined
+  let textId = 'glmxml-text'
+
+  for (const chunk of chunks) {
+    if (chunk.type === 'text-start') {
+      textId = chunk.id
+      continue
+    }
+    if (chunk.type === 'text-delta') {
+      texts.push(chunk.delta)
+      continue
+    }
+    if (chunk.type === 'text-end') continue
+    if (chunk.type === 'finish') {
+      finish = chunk
+      continue
+    }
+    passthrough.push(chunk)
+  }
+
+  const { text, calls } = extractGlmXml(texts.join(''))
+  const out: LanguageModelV4StreamPart[] = [...passthrough]
+
+  if (text) {
+    out.push({ type: 'text-start', id: textId })
+    out.push({ type: 'text-delta', id: textId, delta: text })
+    out.push({ type: 'text-end', id: textId })
+  }
+
+  for (const call of calls) {
+    const id = nextToolCallId()
+    const input = JSON.stringify(call.args)
+    out.push({ type: 'tool-input-start', id, toolName: call.name })
+    out.push({ type: 'tool-input-delta', id, delta: input })
+    out.push({ type: 'tool-input-end', id })
+    out.push({ type: 'tool-call', toolCallId: id, toolName: call.name, input })
+  }
+
+  if (finish) {
+    const finishReason = calls.length > 0 && finish.finishReason.unified === 'stop'
+      ? { unified: 'tool-calls' as const, raw: finish.finishReason.raw }
+      : finish.finishReason
+    out.push({ ...finish, finishReason })
+  }
+
+  return out
+}
+
+export const glmXmlToolMiddleware: LanguageModelMiddleware = {
+  specificationVersion: 'v4',
+  wrapGenerate: async ({ doGenerate }) => {
+    const result = await doGenerate()
+    const { content, recovered } = recoverGlmXmlContent(result.content)
+    if (recovered === 0) return result
+    const finishReason = result.finishReason.unified === 'stop'
+      ? { unified: 'tool-calls' as const, raw: result.finishReason.raw }
+      : result.finishReason
+    return { ...result, content, finishReason }
+  },
+  wrapStream: async ({ doStream }) => {
+    const { stream, ...rest } = await doStream()
+    const chunks: LanguageModelV4StreamPart[] = []
+    const transform = new TransformStream<LanguageModelV4StreamPart, LanguageModelV4StreamPart>({
+      transform(chunk) {
+        chunks.push(chunk)
+      },
+      flush(controller) {
+        for (const chunk of rewriteGlmXmlStream(chunks)) controller.enqueue(chunk)
+      },
+    })
+    return { stream: stream.pipeThrough(transform), ...rest }
+  },
+}
+
+/** Wrap a Gateway model id so leaked GLM XML becomes tool-call parts. */
+export function wrapGlmXmlModel(modelId: string) {
+  return wrapLanguageModel({
+    model: gateway(modelId),
+    middleware: glmXmlToolMiddleware,
+  })
+}

--- a/apps/evi/agent/lib/glm-xml.test.ts
+++ b/apps/evi/agent/lib/glm-xml.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { extractGlmXml, stripGlmMarkup, usesGlmXmlProtocol } from './glm-xml'
+
+describe('usesGlmXmlProtocol', () => {
+  it('matches GLM model ids', () => {
+    expect(usesGlmXmlProtocol('zai/glm-5.3-flash')).toBe(true)
+    expect(usesGlmXmlProtocol('z-ai/glm-4.7')).toBe(true)
+    expect(usesGlmXmlProtocol('anthropic/claude-sonnet-4.6')).toBe(false)
+  })
+})
+
+describe('extractGlmXml', () => {
+  it('recovers a call mixed into a Slack status line', () => {
+    const raw = [
+      'Working on it: I\'m checking the Vercel runtime errors for the docs project first so the issue carries real evidence, then I\'ll create it on Linear.',
+      '<tool_call>vercel__get_runtime_errors<arg_key>teamId</arg_key><arg_value>team_X7ikPPn4YpZ4APwufE36i53I</arg_value><arg_key>limit</arg_key><arg_value>20</arg_value></tool_call>',
+    ].join('\n')
+
+    expect(extractGlmXml(raw)).toEqual({
+      text: 'Working on it: I\'m checking the Vercel runtime errors for the docs project first so the issue carries real evidence, then I\'ll create it on Linear.',
+      calls: [
+        {
+          name: 'vercel__get_runtime_errors',
+          args: { teamId: 'team_X7ikPPn4YpZ4APwufE36i53I', limit: 20 },
+        },
+      ],
+    })
+  })
+
+  it('recovers several calls in one blob', () => {
+    const raw = '<tool_call>linear__list_issues<arg_key>query</arg_key><arg_value>chat</arg_value></tool_call><tool_call>connection_search<arg_key>q</arg_key><arg_value>vercel logs</arg_value></tool_call>'
+    const { calls, text } = extractGlmXml(raw)
+    expect(text).toBe('')
+    expect(calls).toEqual([
+      { name: 'linear__list_issues', args: { query: 'chat' } },
+      { name: 'connection_search', args: { q: 'vercel logs' } },
+    ])
+  })
+
+  it('parses JSON object arguments', () => {
+    const { calls } = extractGlmXml('<tool_call>save_issue<arg_key>input</arg_key><arg_value>{"title":"Docs chat down"}</arg_value></tool_call>')
+    expect(calls).toEqual([{ name: 'save_issue', args: { input: { title: 'Docs chat down' } } },])
+  })
+
+  it('leaves ordinary replies alone', () => {
+    expect(extractGlmXml('The issue is filed.')).toEqual({
+      text: 'The issue is filed.',
+      calls: [],
+    })
+  })
+})
+
+describe('stripGlmMarkup', () => {
+  it('drops Slack-eaten XML fragments so they never become the reply', () => {
+    expect(stripGlmMarkup('</arg_key><arg_value>team_X7ikPPn4YpZ4APwufE36i53I</arg_value></tool_call>')).toBe('')
+    expect(stripGlmMarkup(
+      'Working on it.\n<arg_value>team_X7ikPPn4YpZ4APwufE36i53I</arg_value><arg_key>limit</arg_key><arg_value>20</arg_value></tool_call>',
+    )).toBe('Working on it.')
+    expect(stripGlmMarkup('<arg_key>teamId</arg_key><arg_value>team_X7ikPPn4YpZ4APwufE36i53I</arg_value></tool_call>')).toBe('')
+  })
+})

--- a/apps/evi/agent/lib/glm-xml.ts
+++ b/apps/evi/agent/lib/glm-xml.ts
@@ -1,0 +1,73 @@
+/**
+ * GLM 4.5+ / 5.x native tool calls are XML in the text stream:
+ * `<tool_call>{name}<arg_key>k</arg_key><arg_value>v</arg_value>...</tool_call>`.
+ * Some Gateway deployments parse that into tool-call parts; others leave it in
+ * `content` with `finish_reason: stop`, which Slack then posts as the reply.
+ */
+
+export interface GlmXmlCall {
+  readonly name: string
+  readonly args: Record<string, unknown>
+}
+
+export interface GlmXmlExtraction {
+  readonly text: string
+  readonly calls: readonly GlmXmlCall[]
+}
+
+const TOOL_CALL_BLOCK = /<tool_call>([\s\S]*?)<\/tool_call>/g
+const ARG_PAIR = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/g
+const GLM_TAG = /<\/?(?:tool_call|arg_key|arg_value)\b/
+
+/** GLM 4.5+ and 5.x share this XML tool protocol. */
+export function usesGlmXmlProtocol(modelId: string): boolean {
+  return /glm/i.test(modelId)
+}
+
+export function extractGlmXml(raw: string): GlmXmlExtraction {
+  const calls: GlmXmlCall[] = []
+  const withoutBlocks = raw.replace(TOOL_CALL_BLOCK, (_block, body: string) => {
+    const call = parseToolCallBody(body)
+    if (call) calls.push(call)
+    return ''
+  })
+  return { text: stripGlmMarkup(withoutBlocks), calls }
+}
+
+function parseToolCallBody(body: string): GlmXmlCall | null {
+  const nameMatch = body.match(/^\s*([^\s<]+)/)
+  if (!nameMatch) return null
+  const args: Record<string, unknown> = {}
+  for (const match of body.matchAll(new RegExp(ARG_PAIR.source, 'g'))) {
+    args[match[1]!] = parseArgValue(match[2]!)
+  }
+  return { name: nameMatch[1]!, args }
+}
+
+function parseArgValue(raw: string): unknown {
+  const trimmed = raw.trim()
+  if (trimmed === '') return ''
+  if (trimmed === 'true') return true
+  if (trimmed === 'false') return false
+  if (trimmed === 'null') return null
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed)
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}'))
+    || (trimmed.startsWith('[') && trimmed.endsWith(']'))
+    || (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    try {
+      return JSON.parse(trimmed)
+    } catch {
+      return raw
+    }
+  }
+  return raw
+}
+
+/** Drop leftover GLM tags and anything after the first one, including Slack-eaten fragments. */
+export function stripGlmMarkup(text: string): string {
+  const idx = text.search(GLM_TAG)
+  const cut = idx === -1 ? text : text.slice(0, idx)
+  return cut.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
+}

--- a/apps/evi/docs/notes.md
+++ b/apps/evi/docs/notes.md
@@ -104,6 +104,16 @@ rather than routing elsewhere. A hand-written `order` cannot fix this — a
 provider it names that ZDR has dropped is skipped silently, which reads as
 vetted while doing nothing.
 
+**GLM 5.x tool calls are XML, and some Gateway deployments leak that XML
+as text.** The model emits
+`<tool_call>name<arg_key>k</arg_key><arg_value>v</arg_value></tool_call>`.
+A working parser turns that into `tool_calls`; a miss returns
+`finish_reason: stop` and the XML as `content`. Slack then posts the tags,
+and eats the opening ones as mrkdwn, which is why a thread showed fragments.
+`agent/lib/glm-xml.ts` recovers complete blocks into tool-call parts and
+strips leftovers. The wrap is applied at `step.started` because session/turn
+selections cannot be live LanguageModel objects.
+
 **`GET /v1/models` returns the real rate card**, including `input_cache_read`.
 Reconstructing an observed turn from it matched eve's reported `costUsd` to four
 decimals, which is how the overspend was found.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

None.

### 📚 Description

Some AI Gateway deployments leave GLM 5.x native tool calls in the text stream (`<tool_call>…</tool_call>`) with `finish_reason: stop` instead of turning them into `tool_calls`. Eve posted that XML to Slack, and Slack mrkdwn ate the opening tags, which is why the thread showed fragments instead of running the tools.

This wraps the GLM model at `step.started` (session/turn selections must stay model-id strings) and recovers complete XML blocks into tool-call parts. Leftover GLM tags are stripped so they never reach Slack.

No package changeset: `apps/evi` only.

### 📝 Checklist

- [x] I have updated the documentation accordingly.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://hrcdworkspace.slack.com/archives/D0BUS2YRE4D/p1788474581618509?thread_ts=1788474581.618509&cid=D0BUS2YRE4D)

<div><a href="https://cursor.com/agents/bc-08dc0165-b0f9-5137-8c83-fb690e2a31a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08dc0165-b0f9-5137-8c83-fb690e2a31a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GLM model tool calls encoded in XML, including recovery from malformed or truncated responses.
  * Preserves regular response text while converting recognized XML tool calls into executable tool actions.
  * Supports tool calls in both standard and streaming responses.

* **Documentation**
  * Added guidance on GLM XML tool-call handling and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->