### PR TITLE
fix: preserve error details and correct logger contracts

### DIFF
--- a/.changeset/fix-logger-source-types.md
+++ b/.changeset/fix-logger-source-types.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Preserve error details in global `log.error(Error)` calls and keep `audit()` calls safe when request logging is disabled or excluded. Correct generic logger accessor types and load the Nitro 3 hook declarations during source type checking.

--- a/.changeset/fix-logger-source-types.md
+++ b/.changeset/fix-logger-source-types.md
@@ -2,4 +2,4 @@
 "evlog": patch
 ---
 
-Preserve error details in global `log.error(Error)` calls and keep `audit()` calls safe when request logging is disabled or excluded. Correct generic logger accessor types and load the Nitro 3 hook declarations during source type checking.
+Preserve error details in global `log.error(Error)` calls, replace circular error metadata with `[Circular]`, and keep `audit()` calls safe when request logging is disabled or excluded. Correct generic logger accessor types and load the Nitro 3 hook declarations during source type checking.

--- a/packages/evlog/src/elysia/index.ts
+++ b/packages/evlog/src/elysia/index.ts
@@ -40,7 +40,9 @@ export type EvlogElysiaOptions = BaseEvlogOptions
  * }
  * ```
  */
-export function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
+export function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T>
+// eslint-disable-next-line no-redeclare -- TypeScript overload implementation.
+export function useLogger(): AuditableLogger {
   const logger = storage.getStore()
   if (!logger || !activeLoggers.has(logger)) {
     throw new Error(
@@ -48,7 +50,7 @@ export function useLogger<T extends object = Record<string, unknown>>(): Auditab
       + 'Make sure app.use(evlog()) is registered before your routes.',
     )
   }
-  return logger as AuditableLogger<T>
+  return logger
 }
 
 interface ElysiaContext {

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -742,6 +742,25 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
   }
 }
 
+function removeErrorCycles(value: unknown, ancestors: WeakSet<object>): unknown {
+  if (value === null || typeof value !== 'object') return value
+  if (ancestors.has(value)) return '[Circular]'
+
+  ancestors.add(value)
+  let changed = false
+  const visit = (item: unknown): unknown => {
+    const result = removeErrorCycles(item, ancestors)
+    if (!Object.is(result, item)) changed = true
+    return result
+  }
+  const copy = Array.isArray(value)
+    ? value.map(visit)
+    : Object.fromEntries(Object.entries(value).map(([key, item]) => [key, visit(item)]))
+  ancestors.delete(value)
+
+  return changed ? copy : value
+}
+
 function serializeError(err: Error): Record<string, unknown> {
   const errorObj: Record<string, unknown> = {
     name: err.name,
@@ -749,8 +768,9 @@ function serializeError(err: Error): Record<string, unknown> {
     stack: isDev() ? compactStackForStorage(err.stack) : err.stack,
   }
   const errRecord = err as unknown as Record<string, unknown>
+  const ancestors = new WeakSet<object>([err])
   for (const k of ['code', 'status', 'statusText', 'statusCode', 'statusMessage', 'data', 'cause', 'internal'] as const) {
-    if (k in err) errorObj[k] = errRecord[k]
+    if (k in err) errorObj[k] = removeErrorCycles(errRecord[k], ancestors)
   }
 
   if (EvlogError.isEvlogError(err)) {

--- a/packages/evlog/src/logger.ts
+++ b/packages/evlog/src/logger.ts
@@ -742,10 +742,33 @@ function prettyPrintWideEvent(event: Record<string, unknown>): void {
   }
 }
 
+function serializeError(err: Error): Record<string, unknown> {
+  const errorObj: Record<string, unknown> = {
+    name: err.name,
+    message: err.message,
+    stack: isDev() ? compactStackForStorage(err.stack) : err.stack,
+  }
+  const errRecord = err as unknown as Record<string, unknown>
+  for (const k of ['code', 'status', 'statusText', 'statusCode', 'statusMessage', 'data', 'cause', 'internal'] as const) {
+    if (k in err) errorObj[k] = errRecord[k]
+  }
+
+  if (EvlogError.isEvlogError(err)) {
+    if (err.code) errorObj.code = err.code
+    if (err.why) errorObj.why = err.why
+    if (err.fix) errorObj.fix = err.fix
+    if (err.link) errorObj.link = err.link
+    if (err.status) errorObj.status = err.status
+  }
+  return errorObj
+}
+
 function createLogMethod(level: LogLevel) {
-  return function logMethod(tagOrEvent: string | Record<string, unknown>, message?: string): void {
+  return function logMethod(tagOrEvent: string | Error | Record<string, unknown>, message?: string): void {
     if (typeof tagOrEvent === 'string' && message !== undefined) {
       emitTaggedLog(level, tagOrEvent, message)
+    } else if (tagOrEvent instanceof Error) {
+      emitWideEvent(level, { error: serializeError(tagOrEvent) })
     } else if (typeof tagOrEvent === 'object') {
       emitWideEvent(level, tagOrEvent)
     } else {
@@ -906,23 +929,7 @@ export function createLogger<T extends object = Record<string, unknown>>(initial
         mergeInto(context, errorContext as Record<string, unknown>)
       }
 
-      const errorObj: Record<string, unknown> = {
-        name: err.name,
-        message: err.message,
-        stack: isDev() ? compactStackForStorage(err.stack) : err.stack,
-      }
-      const errRecord = err as unknown as Record<string, unknown>
-      for (const k of ['code', 'status', 'statusText', 'statusCode', 'statusMessage', 'data', 'cause', 'internal'] as const) {
-        if (k in err) errorObj[k] = errRecord[k]
-      }
-
-      if (EvlogError.isEvlogError(err)) {
-        if (err.code) errorObj.code = err.code
-        if (err.why) errorObj.why = err.why
-        if (err.fix) errorObj.fix = err.fix
-        if (err.link) errorObj.link = err.link
-        if (err.status) errorObj.status = err.status
-      }
+      const errorObj = serializeError(err)
 
       if (isPlainObject(context.error)) {
         mergeInto(context.error as Record<string, unknown>, errorObj)

--- a/packages/evlog/src/next/storage.ts
+++ b/packages/evlog/src/next/storage.ts
@@ -23,7 +23,9 @@ export const evlogStorage = getSharedStorage(
  * })
  * ```
  */
-export function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
+export function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T>
+// eslint-disable-next-line no-redeclare -- TypeScript overload implementation.
+export function useLogger(): AuditableLogger {
   const logger = evlogStorage.getStore()
   if (!logger) {
     throw new Error(
@@ -31,5 +33,5 @@ export function useLogger<T extends object = Record<string, unknown>>(): Auditab
       + 'Wrap your route handler or server action with withEvlog().',
     )
   }
-  return logger as AuditableLogger<T>
+  return logger
 }

--- a/packages/evlog/src/shared/fork.ts
+++ b/packages/evlog/src/shared/fork.ts
@@ -1,5 +1,6 @@
 import type { AsyncLocalStorage } from 'node:async_hooks'
 import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { createRequestLogger, getGlobalDrain } from '../logger'
 import { extractErrorStatus } from './errors'
 import type { MiddlewareLoggerOptions } from './middleware'
@@ -10,9 +11,9 @@ import { runEnrichAndDrain } from './middleware'
  */
 export interface ForkLifecycle {
   /** Called after the child logger is installed in storage, before `fn` runs. */
-  onChildEnter?: (child: RequestLogger) => void
+  onChildEnter?: (child: AuditableLogger) => void
   /** Called after the child has finished (emit + enrich/drain), success or failure. */
-  onChildExit?: (child: RequestLogger) => void
+  onChildExit?: (child: AuditableLogger) => void
 }
 
 /**

--- a/packages/evlog/src/shared/integration.ts
+++ b/packages/evlog/src/shared/integration.ts
@@ -1,5 +1,6 @@
 import type { AsyncLocalStorage } from 'node:async_hooks'
 import type { RequestLogger } from '../types'
+import type { AuditableLogger } from '../audit'
 import { attachForkToLogger } from './fork'
 import { extractSafeHeaders, extractSafeNodeHeaders } from './headers'
 import type { BaseEvlogOptions, MiddlewareLoggerOptions, MiddlewareLoggerResult } from './middleware'
@@ -25,7 +26,7 @@ export interface FrameworkIntegrationSpec<TCtx> {
   name: string
   extractRequest: (ctx: TCtx) => ExtractedRequest
   /** Attach the request logger to the framework context (`c.set('log', logger)`). */
-  attachLogger: (ctx: TCtx, logger: RequestLogger) => void
+  attachLogger: (ctx: TCtx, logger: AuditableLogger) => void
   /**
    * AsyncLocalStorage instance backing `useLogger()`. Required for frameworks
    * where the logger is accessed off the request context (Express, Fastify,

--- a/packages/evlog/src/shared/middleware.ts
+++ b/packages/evlog/src/shared/middleware.ts
@@ -1,6 +1,6 @@
 import type { DrainContext, EnrichContext, RedactConfig, RequestLogger, RouteConfig, TailSamplingContext, WideEvent } from '../types'
 import type { AuditableLogger } from '../audit'
-import { createRequestLogger, getGlobalDrain, getGlobalPluginRunner, isEnabled, markWideEventDrainStarted, shouldKeep } from '../logger'
+import { createRequestLogger, getGlobalDrain, getGlobalPluginRunner, isEnabled, markWideEventDrainStarted, noopLogger, shouldKeep } from '../logger'
 import { isGloballyRedacted, redactEvent, resolveRedactConfig } from '../redact'
 import { elapsedMs } from '../utils'
 import { extractErrorStatus } from './errors'
@@ -89,19 +89,7 @@ export interface MiddlewareLoggerResult {
 }
 
 const noopResult: MiddlewareLoggerResult = {
-  logger: {
-    set() {},
-    error() {},
-    info() {},
-    warn() {},
-    setLevel() {},
-    emit() {
-      return null 
-    },
-    getContext() {
-      return {} 
-    },
-  },
+  logger: noopLogger,
   finish: () => Promise.resolve(null),
   finishResponse: (response) => Promise.resolve(response),
   skipped: true,

--- a/packages/evlog/src/shared/storage.ts
+++ b/packages/evlog/src/shared/storage.ts
@@ -24,15 +24,16 @@ export function createLoggerStorage(contextHint: string, id: string = contextHin
   /** @internal Every registered instance is a real ALS; the registry only widens the type. */
   const storage = getSharedStorage(id, () => new AsyncLocalStorage<AuditableLogger>()) as AsyncLocalStorage<AuditableLogger>
 
-  function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T> {
+  function useLogger<T extends object = Record<string, unknown>>(): AuditableLogger<T>
+  // eslint-disable-next-line no-redeclare -- TypeScript overload implementation.
+  function useLogger(): AuditableLogger {
     const logger = storage.getStore()
     if (!logger) {
       throw new Error(
         `[evlog] useLogger() was called outside of an evlog ${contextHint}`,
       )
     }
-    /** @internal ALS store is untyped; cast satisfies the caller's generic `T`. */
-    return logger as AuditableLogger<T>
+    return logger
   }
 
   return { storage, useLogger }

--- a/packages/evlog/src/types.ts
+++ b/packages/evlog/src/types.ts
@@ -1,4 +1,5 @@
 import type { NitroRuntimeHooks } from 'nitropack/types'
+import type {} from 'nitro/types'
 import type { DevTerminalInput } from './shared/dev-terminal'
 
 declare module 'nitropack/types' {

--- a/packages/evlog/test/core/logger.test.ts
+++ b/packages/evlog/test/core/logger.test.ts
@@ -128,6 +128,64 @@ describe('log', () => {
     expect(drain).toHaveBeenCalledTimes(1)
   })
 
+  it('preserves non-cyclic metadata values and their serialization', () => {
+    const { drain } = createPipelineSpies()
+    initLogger({ pretty: false, redact: false, drain })
+    const data = {
+      timestamp: new Date('2026-01-01T00:00:00Z'),
+      url: new URL('https://example.com'),
+      duration: Number.NaN,
+    }
+    log.error(Object.assign(new Error('Request failed'), { data }))
+
+    const event = defined(findEventViaDrain(drain, event => event.level === 'error'))
+    expect(event.error?.data).toBe(data)
+    expect(JSON.stringify(event)).toContain('2026-01-01T00:00:00.000Z')
+    expect(JSON.stringify(event)).toContain('https://example.com/')
+  })
+
+  it.each([
+    { scoped: false, redact: false },
+    { scoped: true, redact: false },
+    { scoped: false, redact: true },
+    { scoped: true, redact: true },
+  ])('emits cyclic error metadata safely (scoped=$scoped, redact=$redact)', ({ scoped, redact }) => {
+    const { drain } = createPipelineSpies()
+    initLogger({ pretty: false, drain, redact: redact ? { paths: ['error.internal.token'] } : false })
+    const shared = { provider: 'test' }
+    const data: Record<string, unknown> = { first: shared, second: shared }
+    const internal: Record<string, unknown> = { token: 'secret', data }
+    const error = Object.assign(new Error('Payment failed'), { data, internal })
+    error.cause = error
+    data.self = data
+    data.items = [data]
+    internal.self = internal
+
+    expect(() => {
+      if (scoped) {
+        const logger = createLogger()
+        logger.error(error)
+        logger.emit()
+      } else {
+        log.error(error)
+      }
+    }).not.toThrow()
+
+    expect(drain).toHaveBeenCalledTimes(1)
+    const event = defined(findEventViaDrain(drain, event => event.level === 'error'))
+    expect(event.error).toMatchObject({
+      message: 'Payment failed',
+      cause: '[Circular]',
+      data: { first: shared, second: shared, self: '[Circular]', items: ['[Circular]'] },
+      internal: { self: '[Circular]' },
+    })
+    expect(JSON.stringify(event)).toContain(redact ? '[REDACTED]' : 'secret')
+    if (redact) expect(JSON.stringify(event)).not.toContain('secret')
+    expect(error.cause).toBe(error)
+    expect(data.self).toBe(data)
+    expect(internal.token).toBe('secret')
+  })
+
   it('uses error console method for error level', () => {
     const errorSpy = vi.spyOn(console, 'error')
     log.error('db', 'Connection failed')

--- a/packages/evlog/test/core/logger.test.ts
+++ b/packages/evlog/test/core/logger.test.ts
@@ -3,6 +3,7 @@ import { createError } from '../../src/error'
 import { createLogger, createRequestLogger, getEnvironment, initLogger, isEnabled, log } from '../../src/logger'
 import { withFakeTimers } from '../helpers/timers'
 import { defined } from '../helpers/defined'
+import { createPipelineSpies, findEventViaDrain } from '../helpers/framework'
 
 describe('initLogger', () => {
   beforeEach(() => {
@@ -91,6 +92,40 @@ describe('log', () => {
     const [[output]] = infoSpy.mock.calls
     expect(output).toContain('"action":"checkout"')
     expect(output).toContain('"items":3')
+  })
+
+  it('preserves standard Error fields in the global drain', () => {
+    const { drain } = createPipelineSpies()
+    initLogger({ silent: true, redact: false, drain })
+    const error = Object.assign(new Error('Database unavailable'), { code: 'DB_UNAVAILABLE', status: 503 })
+    log.error(error)
+
+    expect(drain).toHaveBeenCalledTimes(1)
+    const event = defined(findEventViaDrain(drain, event => event.level === 'error'))
+    expect(event.error).toMatchObject({
+      name: 'Error', message: 'Database unavailable', code: 'DB_UNAVAILABLE', status: 503,
+    })
+    expect(event.error?.stack).toContain('Database unavailable')
+  })
+
+  it('preserves EvlogError guidance and redacts internal fields in the global drain', () => {
+    const { drain } = createPipelineSpies()
+    initLogger({ silent: true, drain, redact: { paths: ['error.internal.token'] } })
+    const error = createError({
+      message: 'Payment failed', status: 402, code: 'PAYMENT_FAILED',
+      why: 'The card was declined', fix: 'Use another card', link: 'https://example.com/help',
+      internal: { token: 'secret', provider: 'test' },
+    })
+    log.error(error)
+
+    const event = defined(findEventViaDrain(drain, event => event.level === 'error'))
+    expect(event.error).toMatchObject({
+      message: error.message, status: 402, code: 'PAYMENT_FAILED',
+      why: error.why, fix: error.fix, link: error.link,
+      internal: { provider: 'test' },
+    })
+    expect(JSON.stringify(event)).not.toContain('secret')
+    expect(drain).toHaveBeenCalledTimes(1)
   })
 
   it('uses error console method for error level', () => {

--- a/packages/evlog/test/core/middleware.test.ts
+++ b/packages/evlog/test/core/middleware.test.ts
@@ -70,6 +70,25 @@ describe('createMiddlewareLogger', () => {
     expect(skipped).toBe(true)
   })
 
+  it.each(['disabled', 'excluded', 'not-included'])(
+    'accepts audit calls without emitting when logging is %s', async (mode) => {
+      const { drain } = createPipelineSpies()
+      initLogger({ enabled: mode !== 'disabled', drain, silent: true })
+      const { logger, finish, skipped } = createMiddlewareLogger({
+        method: 'GET', path: '/health',
+        exclude: mode === 'excluded' ? ['/health'] : undefined,
+        include: mode === 'not-included' ? ['/api/**'] : undefined,
+      })
+
+      expect(skipped).toBe(true)
+      expect(() => logger.audit({ action: 'health.read', actor: { type: 'user', id: 'u1' } })).not.toThrow()
+      expect(() => logger.audit.deny('denied', { action: 'health.read', actor: { type: 'user', id: 'u1' } })).not.toThrow()
+      expect(logger.getContext()).toEqual({})
+      expect(await finish({ status: 200 })).toBeNull()
+      expect(drain).not.toHaveBeenCalled()
+    },
+  )
+
   it('does not skip when path matches include patterns', () => {
     const { skipped } = createMiddlewareLogger({
       method: 'GET',

--- a/packages/evlog/test/fixtures/logger-types.ts
+++ b/packages/evlog/test/fixtures/logger-types.ts
@@ -1,0 +1,30 @@
+import { log } from '../../src/logger'
+import { useLogger as useNextLogger } from '../../src/next/storage'
+import { createLoggerStorage } from '../../src/shared/storage'
+import { useLogger as useElysiaLogger } from '../../src/elysia'
+
+interface Context { user: { id: string } }
+
+log.error(new Error('failed'))
+const nextLogger = useNextLogger<Context>()
+nextLogger.set({ user: { id: 'u1' } })
+const nextId: string | undefined = nextLogger.getContext().user?.id
+// @ts-expect-error User IDs remain strings in typed request contexts.
+nextLogger.set({ user: { id: 123 } })
+
+const { useLogger } = createLoggerStorage('test context')
+const sharedLogger = useLogger<Context>()
+sharedLogger.set({ user: { id: 'u2' } })
+const sharedId: string | undefined = sharedLogger.getContext().user?.id
+// @ts-expect-error User IDs remain strings in typed request contexts.
+sharedLogger.set({ user: { id: 123 } })
+
+void nextId
+void sharedId
+
+const elysiaLogger = useElysiaLogger<Context>()
+elysiaLogger.set({ user: { id: 'u3' } })
+const elysiaId: string | undefined = elysiaLogger.getContext().user?.id
+// @ts-expect-error User IDs remain strings in typed request contexts.
+elysiaLogger.set({ user: { id: 123 } })
+void elysiaId

--- a/packages/evlog/test/toolkit/logger-types.test.ts
+++ b/packages/evlog/test/toolkit/logger-types.test.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { expect, it } from 'vitest'
+
+it('typechecks logger source and generic accessors without importing Nitro first', () => {
+  const packageRoot = fileURLToPath(new URL('../..', import.meta.url))
+  const fixture = fileURLToPath(new URL('../fixtures/logger-types.ts', import.meta.url))
+  const config = ts.readConfigFile(`${packageRoot}/tsconfig.json`, ts.sys.readFile)
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, packageRoot)
+  const program = ts.createProgram([fixture], { ...parsed.options, noEmit: true })
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+
+  expect(ts.formatDiagnostics(diagnostics, {
+    getCurrentDirectory: () => packageRoot,
+    getCanonicalFileName: file => file,
+    getNewLine: () => '\n',
+  })).toBe('')
+})

--- a/packages/evlog/test/toolkit/logger-types.test.ts
+++ b/packages/evlog/test/toolkit/logger-types.test.ts
@@ -15,4 +15,4 @@ it('typechecks logger source and generic accessors without importing Nitro first
     getCanonicalFileName: file => file,
     getNewLine: () => '\n',
   })).toBe('')
-})
+}, 30_000)


### PR DESCRIPTION
Global `log.error(Error)` now preserves the message, stack and structured error fields. Global and scoped loggers replace circular error metadata with `[Circular]` without mutating the original error or changing non-cyclic metadata values. Excluded or disabled request loggers accept `audit()` and `audit.deny()` without throwing. Generic logger accessors retain their context types, and Nitro 3 hook declarations load during source type checking.

Includes regression tests for both runtime bugs and a source-compilation test for the logger contracts. Found while reviewing #660; this PR is independent of its drain lifecycle change.

Validation: workspace lint, typecheck and tests; evlog coverage thresholds; failing regression tests verified before the fix.

The `just-use-evlog` preview fails on an existing `main` issue: `LandingComark.ts` imports `defineComarkRendererComponent`, which is not exported by the installed `@comark/vue@0.6.2`. This PR does not modify that application.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error logs now preserve standard and custom error details, including codes, status information, stack traces, and troubleshooting guidance.
  * Circular error metadata is safely represented without causing logging failures.
  * Audit calls no longer fail when request logging is disabled or a route is excluded.
  * Logger accessors now provide more accurate type checking across supported integrations.

* **Developer Experience**
  * Logger context types are more consistently supported across frameworks and shared usage patterns.
  * Source type checking now correctly recognizes Nitro hook declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->