### PR TITLE
fix: restore just-use-evlog rendering with current Comark API

### DIFF
--- a/apps/just-use-evlog/app/components/LandingComark.ts
+++ b/apps/just-use-evlog/app/components/LandingComark.ts
@@ -1,4 +1,4 @@
-import { defineComarkRendererComponent } from '@comark/vue'
+import { defineMarkdownDocumentComponent } from '@comark/vue'
 import LandingBadges from './LandingBadges.vue'
 import LandingCtas from './LandingCtas.vue'
 import LandingH1 from './LandingH1.vue'
@@ -6,7 +6,7 @@ import LandingH2 from './LandingH2.vue'
 import LandingMidCta from './LandingMidCta.vue'
 import LandingStats from './LandingStats.vue'
 
-export default defineComarkRendererComponent({
+export default defineMarkdownDocumentComponent({
   name: 'LandingComark',
   components: {
     'h1': LandingH1,

--- a/apps/just-use-evlog/app/pages/index.vue
+++ b/apps/just-use-evlog/app/pages/index.vue
@@ -73,7 +73,7 @@ useSeoMeta({
     <div class="pointer-events-none absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[400px] bg-white/3 rounded-full blur-3xl" aria-hidden="true" />
     <div class="relative z-10">
       <main class="mx-auto max-w-2xl px-6 pb-24 pt-14 md:px-8 md:pt-20 md:pb-32">
-        <LandingComark v-if="tree" :tree />
+        <LandingComark v-if="tree" :value="tree" />
       </main>
 
       <footer class="border-t border-default px-6 py-10 md:px-8">

--- a/apps/just-use-evlog/content.config.ts
+++ b/apps/just-use-evlog/content.config.ts
@@ -1,10 +1,14 @@
-import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { defineCollection, defineContentConfig, z } from '@nuxt/content'
 
 export default defineContentConfig({
   collections: {
     landing: defineCollection({
       type: 'page',
       source: '**/*.md',
+      schema: z.object({
+        ogTitle: z.string().optional(),
+        ogDescription: z.string().optional(),
+      }),
     }),
   },
 })


### PR DESCRIPTION
`just-use-evlog` failed to build after Comark renamed its renderer API. Use `defineMarkdownDocumentComponent` and pass the parsed document through `value` so the landing content renders with the installed Comark version. Declare the existing Open Graph fields in the content schema so the page also passes direct component type checking.

Validation: reproduced the original build failure; production build and prerender now pass, with the heading, custom components, documentation links and Open Graph metadata checked in the generated HTML. Workspace lint, typecheck, tests and coverage pass, alongside direct application type checking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated landing-page content rendering to use the current Markdown document component interface.
  - Improved how landing-page content values are passed to the renderer.

- **New Features**
  - Added optional Open Graph title and description fields for landing-page content, enabling richer social sharing metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->