### PR TITLE
fix: isolate async storage capability probes

### DIFF
--- a/.agents/skills/create-framework-integration/SKILL.md
+++ b/.agents/skills/create-framework-integration/SKILL.md
@@ -153,6 +153,8 @@ export function evlog(options: Evlog{Framework}Options = {}): FrameworkMiddlewar
 - **SvelteKit**: `src/sveltekit/index.ts`. `evlog()` handle + `evlogHandleError()` + `createEvlogHooks()`
 - **Workers**: `src/workers/index.ts`. `defineWorkerFetch` / `withEvlog`, no ALS `useLogger()` (compat-flag constraint)
 
+For integrations that bind with `enterWith()`, use `createSharedEnterWithStorage` from `src/shared/asyncStorageScope.ts`. Its capability probe runs in a temporary scope with a distinct store, preserving the importer's async context on Bun and Node.
+
 ### Key Architecture Rules
 
 1. **Prefer `defineFrameworkIntegration`**: it handles header normalization, request-id generation, ALS, fork attachment, and `waitUntil`.

--- a/.changeset/plenty-foxes-tickle.md
+++ b/.changeset/plenty-foxes-tickle.md
@@ -1,0 +1,5 @@
+---
+"evlog": patch
+---
+
+Fix Bun crashes and test lifecycle timeouts when importing the Elysia or eve integration by isolating the AsyncLocalStorage capability probe from the caller's context.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
           - name: Set up pnpm and Node
             uses: ./.github/actions/setup
 
+      - name: Set up Bun for import regressions
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
       # evlog runs once below, under coverage, which enforces its thresholds
       - name: Test workspace
         run: pnpm exec turbo run test --affected --filter='!evlog'

--- a/packages/evlog/src/shared/asyncStorageScope.ts
+++ b/packages/evlog/src/shared/asyncStorageScope.ts
@@ -19,16 +19,17 @@ export interface AsyncLocalStorageLike<T> {
  * Whether this runtime provides a working native `AsyncLocalStorage.enterWith()`.
  *
  * Cloudflare Workers expose `enterWith` on the prototype but throw when it is
- * called, so a `typeof` check alone is not enough — we probe with a call.
+ * called, so a `typeof` check alone is not enough. Probe inside a temporary
+ * scope so importing an integration preserves the caller's async context.
  */
-export function supportsAsyncLocalStorageEnterWith(
-  storage: { enterWith?: unknown },
+export function supportsAsyncLocalStorageEnterWith<T>(
+  storage: AsyncLocalStorageLike<T>,
 ): boolean {
   if (typeof storage.enterWith !== 'function') return false
   try {
-    // Must call as a method — unbound enterWith loses `this` and throws on Node.
-    const probe = storage as { enterWith: (store: undefined) => void }
-    probe.enterWith(undefined)
+    const probe = storage as AsyncLocalStorageLike<unknown>
+    // A distinct store forces a new scope; run(undefined) can reuse the caller's.
+    probe.run({}, () => probe.enterWith(undefined))
     return true
   } catch {
     return false

--- a/packages/evlog/test/README.md
+++ b/packages/evlog/test/README.md
@@ -27,6 +27,7 @@ verify the test really exercises the framework's runtime, not a substitute.
 | `frameworks/hono.test.ts` | `app.request(...)` Fetch API | Real Hono router, real handler dispatch |
 | `frameworks/fastify.test.ts` | `app.inject(...)` (Light My Request) | Real Fastify lifecycle (preHandler / handler / response hooks) |
 | `frameworks/elysia.test.ts` | `app.handle(new Request(...))` | Real Elysia handler |
+| `shared/bun-import.test.ts` | Bun subprocesses importing Elysia and eve | Top-level await, `bun:test` lifecycle hooks, and a real Elysia request with `useLogger()` |
 | `frameworks/nestjs.test.ts` | Extracts middleware via `EvlogModule.configure()` and mounts on Express | Module API + the Connect-style middleware itself; **does NOT boot NestFactory** |
 | `frameworks/nestjs-real-runtime.test.ts` | `Test.createTestingModule(...)` + `app.init()` + supertest | **Real NestFactory boot, real DI, real exception filter pipeline** |
 | `frameworks/react-router.test.ts` | Calls middleware directly with `new RouterContextProvider()` from `react-router` | Real react-router context provider (set/get semantics, throws on missing) |
@@ -149,6 +150,10 @@ pnpm test:e2e                                   # real network (skipped without 
 pnpm run mutate                                 # Stryker (slow; weekly cron in CI)
 ```
 
+`shared/bun-import.test.ts` requires `bun` on `PATH` and skips locally when it is
+absent. CI installs Bun 1.3.14 to exercise import-time async context regressions.
+The `.mjs` fixtures run in Bun, outside Vitest's TypeScript test discovery.
+
 ## Coverage thresholds
 
 The thresholds in [`packages/evlog/vitest.config.ts`](../vitest.config.ts) (`statements` / `branches` / `functions` / `lines`) are kept ~3 points below the measured baseline so a real regression fails CI but flaky-but-fast metrics don't generate false alarms.
@@ -170,12 +175,13 @@ Set `EVLOG_SLOW_TEST_BUDGET_MS=300 CI=1 pnpm test` to surface tests above 300ms
 
 ## CI structure
 
-`.github/workflows/ci.yml` runs five independent jobs in parallel on every PR:
+`.github/workflows/ci.yml` runs four jobs in parallel on every PR:
 
-- `lint` — `pnpm run dev:prepare` + `pnpm run lint`
-- `typecheck` — `pnpm run dev:prepare` + `pnpm run typecheck`
-- `test` — `pnpm run dev:prepare` + `pnpm run build:package`, then `vitest run --shard=N/4` across a 4-way matrix
-- `coverage` — `pnpm run dev:prepare` + `pnpm run build:package` + `pnpm --filter evlog run test:coverage` (enforces the thresholds in `vitest.config.ts`)
-- `publish` — needs all of the above; runs `pkg-pr-new publish` for evlog + nuxthub on PR / main / manual dispatch
+- `quality`: lint and typecheck affected packages, excluding `evlog-telemetry` from typecheck.
+- `test`: test affected workspace packages, run content checks, then build evlog and run its full coverage suite. Bun 1.3.14 runs the import regressions. CLI changes also run the sandbox smoke tests.
+- `examples`: build affected examples.
+- `publish`: build and publish preview packages independently of the other checks.
+
+The `ci` job checks that `quality`, `test`, and `examples` succeeded.
 
 Mutation testing is intentionally separate: `.github/workflows/mutation.yml` runs Stryker on a weekly Monday cron and on `workflow_dispatch` (Stryker is too slow to gate every PR).

--- a/packages/evlog/test/shared/asyncStorageScope.test.ts
+++ b/packages/evlog/test/shared/asyncStorageScope.test.ts
@@ -56,6 +56,53 @@ describe('asyncStorageScope', () => {
     expect(supportsAsyncLocalStorageEnterWith(new AsyncLocalStorage<string>())).toBe(true)
   })
 
+  it('preserves the active store when probing native enterWith', async () => {
+    const storage = new AsyncLocalStorage<object>()
+    const logger = { requestId: 'active' }
+
+    await storage.run(logger, async () => {
+      expect(supportsAsyncLocalStorageEnterWith(storage)).toBe(true)
+      expect(storage.getStore()).toBe(logger)
+      await Promise.resolve()
+      expect(storage.getStore()).toBe(logger)
+    })
+    expect(storage.getStore()).toBeUndefined()
+  })
+
+  it('isolates the probe even when the caller has no store', () => {
+    const native = new AsyncLocalStorage<unknown>()
+    const storage = {
+      getStore: native.getStore.bind(native),
+      run: native.run.bind(native),
+      enterWith(store: unknown) {
+        expect(native.getStore()).toBeDefined()
+        native.enterWith(store)
+      },
+    }
+
+    expect(supportsAsyncLocalStorageEnterWith(storage)).toBe(true)
+    expect(storage.getStore()).toBeUndefined()
+  })
+
+  it('restores the active store when enterWith mutates it and throws', () => {
+    const native = new AsyncLocalStorage<unknown>()
+    const storage = {
+      getStore: native.getStore.bind(native),
+      run: native.run.bind(native),
+      enterWith(store: unknown) {
+        native.enterWith(store)
+        throw new Error('enterWith is not supported')
+      },
+    }
+    const logger = { requestId: 'active' }
+
+    storage.run(logger, () => {
+      expect(supportsAsyncLocalStorageEnterWith(storage)).toBe(false)
+      expect(storage.getStore()).toBe(logger)
+    })
+    expect(storage.getStore()).toBeUndefined()
+  })
+
   it('detects throwing enterWith as unsupported', () => {
     class LocalAsyncLocalStorage extends AsyncLocalStorage<string> {}
     Object.defineProperty(LocalAsyncLocalStorage.prototype, 'enterWith', {

--- a/packages/evlog/test/shared/bun-import.test.ts
+++ b/packages/evlog/test/shared/bun-import.test.ts
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const bunAvailable = spawnSync('bun', ['--version']).status === 0
+
+describe.skipIf(!bunAvailable)('Bun integration imports', () => {
+  it.each([
+    ['top-level await', ['run', fileURLToPath(new URL('./fixtures/bun-import.mjs', import.meta.url))]],
+    ['test lifecycle hooks', ['test', '--timeout', '1000', fileURLToPath(new URL('./fixtures/bun-import.test.mjs', import.meta.url))]],
+  ])('preserves the async context for %s', (_, args) => {
+    const result = spawnSync('bun', args, { encoding: 'utf8', timeout: 10_000 })
+
+    expect(result.error).toBeUndefined()
+    expect(result.signal, result.stderr).toBeNull()
+    expect(result.status, result.stderr).toBe(0)
+  })
+})

--- a/packages/evlog/test/shared/fixtures/bun-import.mjs
+++ b/packages/evlog/test/shared/fixtures/bun-import.mjs
@@ -1,0 +1,4 @@
+import '../../../src/elysia/index.ts'
+import '../../../src/eve/index.ts'
+
+await Promise.resolve()

--- a/packages/evlog/test/shared/fixtures/bun-import.test.mjs
+++ b/packages/evlog/test/shared/fixtures/bun-import.test.mjs
@@ -1,0 +1,46 @@
+import { afterAll, afterEach, beforeEach, expect, test } from 'bun:test'
+import { Elysia } from 'elysia'
+import { evlog, useLogger } from '../../../src/elysia/index.ts'
+import { initLogger } from '../../../src/logger.ts'
+import '../../../src/eve/index.ts'
+
+initLogger({ silent: true })
+
+let beforeCalls = 0
+let afterCalls = 0
+
+beforeEach(async () => {
+  await Promise.resolve()
+  beforeCalls++
+})
+
+afterEach(async () => {
+  await Promise.resolve()
+  afterCalls++
+})
+
+afterAll(() => {
+  expect(beforeCalls).toBe(2)
+  expect(afterCalls).toBe(2)
+})
+
+test('completes the first test after importing integrations', async () => {
+  const app = new Elysia()
+    .use(evlog())
+    .get('/context', async ({ log }) => {
+      expect(useLogger()).toBe(log)
+      await Promise.resolve()
+      expect(useLogger()).toBe(log)
+      return 'ok'
+    })
+
+  const response = await app.handle(new Request('http://localhost/context'))
+  expect(response.status).toBe(200)
+  expect(await response.text()).toBe('ok')
+  expect(beforeCalls).toBe(1)
+})
+
+test('completes the next test and its lifecycle hooks', () => {
+  expect(beforeCalls).toBe(2)
+  expect(afterCalls).toBe(1)
+})


### PR DESCRIPTION
Closes #496.

Importing `evlog/elysia` or `evlog/eve` calls an AsyncLocalStorage capability probe that mutates the caller's async context. This can crash Bun, stall `bun:test` lifecycle hooks, and clear an active store on Node. Run the probe inside a temporary scope with a distinct store, preserving the caller's context while retaining the Cloudflare Workers fallback.

Adds regression tests for context restoration, Bun imports with top-level await, and Bun test hooks with a real Elysia request. CI installs Bun 1.3.14. Includes a patch changeset and updated integration/test guidance.

Validation: full lint passes, all 1,904 evlog tests pass with coverage above every threshold, and the remaining workspace tests and typechecks pass. Local validation used direct installed Vitest and vue-tsc executables where stale pnpm shims blocked the standard test/typecheck scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented crashes and test lifecycle timeouts when importing Elysia and Eve integrations on Bun.
  - Preserved async context during capability checks across awaited operations.

- **Tests**
  - Added Bun import regression coverage, including top-level await and test lifecycle hooks.
  - Expanded coverage for async context preservation and restoration.

- **Documentation**
  - Documented Bun testing requirements, runtime coverage, and the updated CI job structure.
  - Added integration guidance for async context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->